### PR TITLE
feat(ui): improve onboarding and inspector experience

### DIFF
--- a/src/ml_pipeline_studio/app.py
+++ b/src/ml_pipeline_studio/app.py
@@ -7,11 +7,13 @@ import sys
 from PySide6.QtWidgets import QApplication
 
 from ml_pipeline_studio.ui.main_window import MainWindow
+from ml_pipeline_studio.ui.theme import configure_application_font
 
 
 def main() -> None:
     app = QApplication(sys.argv)
     app.setApplicationName("ML Pipeline Studio")
+    configure_application_font(app)
     win = MainWindow()
     win.show()
     sys.exit(app.exec())

--- a/src/ml_pipeline_studio/app.py
+++ b/src/ml_pipeline_studio/app.py
@@ -4,6 +4,13 @@ from __future__ import annotations
 
 import sys
 
+
+from ml_pipeline_studio.nodegraphqt_compat import apply_nodegraphqt_compat
+from ml_pipeline_studio.qt_plugin_bootstrap import apply_qt_plugin_environment
+
+apply_qt_plugin_environment()
+apply_nodegraphqt_compat()
+
 from PySide6.QtWidgets import QApplication
 
 from ml_pipeline_studio.ui.main_window import MainWindow

--- a/src/ml_pipeline_studio/app.py
+++ b/src/ml_pipeline_studio/app.py
@@ -4,20 +4,18 @@ from __future__ import annotations
 
 import sys
 
-
 from ml_pipeline_studio.nodegraphqt_compat import apply_nodegraphqt_compat
 from ml_pipeline_studio.qt_plugin_bootstrap import apply_qt_plugin_environment
 
 apply_qt_plugin_environment()
 apply_nodegraphqt_compat()
 
-from PySide6.QtWidgets import QApplication
-
-from ml_pipeline_studio.ui.main_window import MainWindow
-from ml_pipeline_studio.ui.theme import configure_application_font
-
-
 def main() -> None:
+    from PySide6.QtWidgets import QApplication
+
+    from ml_pipeline_studio.ui.main_window import MainWindow
+    from ml_pipeline_studio.ui.theme import configure_application_font
+
     app = QApplication(sys.argv)
     app.setApplicationName("ML Pipeline Studio")
     configure_application_font(app)

--- a/src/ml_pipeline_studio/nodegraphqt_compat.py
+++ b/src/ml_pipeline_studio/nodegraphqt_compat.py
@@ -1,0 +1,99 @@
+"""Compatibility shims for NodeGraphQt against newer PySide6 releases.
+
+NodeGraphQt 0.6.x ships ``PropSpinBox``/``PropDoubleSpinBox`` whose ``__init__``
+calls ``self.setButtonSymbols(self.NoButtons)``. PySide6 >= 6.7 stopped
+exposing scoped-enum members as *instance* attributes (class-level access like
+``QSpinBox.NoButtons`` still works), so the unmodified library raises::
+
+    AttributeError: 'PropDoubleSpinBox' object has no attribute 'NoButtons'
+
+the first time the Inspector dock builds an editor for a numeric property.
+
+The shim re-implements those two ``__init__`` methods to use the
+``QAbstractSpinBox.ButtonSymbols`` enum directly.
+
+We also patch property labels to be easier to scan in the inspector:
+- convert underscored labels into Title Case.
+- ensure the built-in `name` field uses `Name`.
+
+This module must run *before* any ``PropertiesBinWidget`` constructs editors.
+"""
+
+from __future__ import annotations
+
+
+_PATCHED = False
+
+
+def apply_nodegraphqt_compat() -> None:
+    """Idempotently patch NodeGraphQt's spinbox property widgets for PySide6 >= 6.7."""
+
+    global _PATCHED
+    if _PATCHED:
+        return
+
+    try:
+        from NodeGraphQt.custom_widgets.properties_bin import (
+            node_property_widgets as _prop_widgets,
+            prop_widgets_base as _base,
+        )
+    except ImportError:
+        return
+
+    try:
+        from PySide6.QtWidgets import (
+            QAbstractSpinBox,
+            QDoubleSpinBox,
+            QSpinBox,
+        )
+    except ImportError:
+        return
+
+    no_buttons = QAbstractSpinBox.ButtonSymbols.NoButtons
+
+    def _patched_spin_init(self, parent=None):  # type: ignore[no-redef]
+        QSpinBox.__init__(self, parent)
+        self._name = None
+        self.setButtonSymbols(no_buttons)
+        self.valueChanged.connect(self._on_value_change)
+
+    def _patched_dspin_init(self, parent=None):  # type: ignore[no-redef]
+        QDoubleSpinBox.__init__(self, parent)
+        self._name = None
+        self.setButtonSymbols(no_buttons)
+        self.valueChanged.connect(self._on_value_change)
+
+    prop_spin = getattr(_base, "PropSpinBox", None)
+    prop_dspin = getattr(_base, "PropDoubleSpinBox", None)
+
+    if prop_spin is not None:
+        prop_spin.__init__ = _patched_spin_init  # type: ignore[method-assign]
+    if prop_dspin is not None:
+        prop_dspin.__init__ = _patched_dspin_init  # type: ignore[method-assign]
+
+    prop_container = getattr(_prop_widgets, "_PropertiesContainer", None)
+    if prop_container is not None:
+        orig_add_widget = prop_container.add_widget
+
+        def _patched_add_widget(self, name, widget, value, label=None, tooltip=None):
+            pretty = label or name
+            pretty = pretty.replace("_", " ").strip().title()
+            return orig_add_widget(self, name, widget, value, pretty, tooltip)
+
+        prop_container.add_widget = _patched_add_widget  # type: ignore[method-assign]
+
+    node_editor = getattr(_prop_widgets, "NodePropEditorWidget", None)
+    if node_editor is not None:
+        orig_init = node_editor.__init__
+
+        def _patched_editor_init(self, node=None, parent=None):
+            orig_init(self, node=node, parent=parent)
+            name_labels = self.findChildren(_prop_widgets.QtWidgets.QLabel)
+            for lbl in name_labels:
+                if lbl.text() == "name":
+                    lbl.setText("Name")
+                    break
+
+        node_editor.__init__ = _patched_editor_init  # type: ignore[method-assign]
+
+    _PATCHED = True

--- a/src/ml_pipeline_studio/nodegraphqt_compat.py
+++ b/src/ml_pipeline_studio/nodegraphqt_compat.py
@@ -21,7 +21,6 @@ This module must run *before* any ``PropertiesBinWidget`` constructs editors.
 
 from __future__ import annotations
 
-
 _PATCHED = False
 
 
@@ -35,6 +34,8 @@ def apply_nodegraphqt_compat() -> None:
     try:
         from NodeGraphQt.custom_widgets.properties_bin import (
             node_property_widgets as _prop_widgets,
+        )
+        from NodeGraphQt.custom_widgets.properties_bin import (
             prop_widgets_base as _base,
         )
     except ImportError:

--- a/src/ml_pipeline_studio/qt_plugin_bootstrap.py
+++ b/src/ml_pipeline_studio/qt_plugin_bootstrap.py
@@ -1,0 +1,209 @@
+"""Ensure Qt can load platform plugins even when QFile cannot list site-packages (sandbox/FS quirks)."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import stat
+import sys
+import tempfile
+from pathlib import Path
+
+# macOS user-flag that Finder/Qt treat as "hidden". PySide6 macOS wheels (>=6.10.x)
+# ship plugin dylibs with this set, which makes Qt's QDir layer (and thus the
+# platform plugin loader) skip them under the default filter.
+_UF_HIDDEN = getattr(stat, "UF_HIDDEN", 0x8000)
+
+
+def _pyside_plugin_root() -> Path | None:
+    try:
+        import PySide6
+    except ImportError:
+        return None
+    base = Path(PySide6.__file__).resolve().parent
+    p = base / "Qt" / "plugins"
+    return p if p.is_dir() else None
+
+
+def _plugins_cache_destination(plugin_root: Path) -> Path:
+    """Flat temp path for mirrored ``Qt/plugins`` (platforms/styles/imageformats).
+
+    Use ``/tmp/mlpqt-…`` (macOS ``realpath``), not nested ``…/ml-pipeline-studio/qt-plugins-…``.
+    On some setups Qt's ``QDir`` refuses to enumerate the latter paths even though
+    POSIX ``listdir`` succeeds; a short single-level dirname under ``/tmp`` behaves correctly.
+    """
+
+    try:
+        import PySide6
+    except ImportError:
+        ver = "unknown"
+    else:
+        ver = PySide6.__version__
+
+    slug = "".join(c if (c.isalnum() or c in "._-+") else "_" for c in ver)[:24].strip("_") or "pyside6"
+    suffix = hashlib.sha256(os.fspath(plugin_root).encode()).hexdigest()[:14]
+
+    if sys.platform == "darwin":
+        base = Path(os.path.realpath("/tmp"))
+    else:
+        base = Path(tempfile.gettempdir()).resolve()
+
+    return base / f"mlpqt-{slug}-{suffix}"
+
+
+# Subset of `Qt/plugins` needed for widgets + cocoa; avoids huge trees (>20 bundles) that QFile
+# sometimes refuses to enumerate in sandboxed IDE sessions.
+_ESSENTIAL_PLUGIN_SUBDIRS = ("platforms", "styles", "imageformats")
+
+
+def _qdir_any_entries(subdir: Path) -> bool:
+    from PySide6.QtCore import QDir
+
+    if not subdir.is_dir():
+        return False
+    dq = QDir(os.fspath(subdir))
+    for ei in dq.entryInfoList():
+        if ei.fileName() not in (".", ".."):
+            return True
+    return False
+
+
+def _qdir_dylibs_visible(subdir: Path) -> bool:
+    from PySide6.QtCore import QDir
+
+    if not subdir.is_dir():
+        return False
+    dq = QDir(os.fspath(subdir))
+    for glob in ("*.dylib", "*.dll", "*.so"):
+        if dq.entryInfoList([glob]):
+            return True
+    return False
+
+
+def _clear_hidden_flag_tree(root: Path) -> int:
+    """Clear macOS ``UF_HIDDEN`` from every file/dir under ``root``.
+
+    Returns the number of paths whose flags we successfully changed. Best-effort:
+    silently ignores paths we can't chflags (e.g. read-only system installs).
+    """
+
+    if not hasattr(os, "chflags"):
+        return 0
+    cleared = 0
+    for current_dir, dirnames, filenames in os.walk(root):
+        for name in list(dirnames) + list(filenames):
+            p = os.path.join(current_dir, name)
+            try:
+                st = os.lstat(p)
+            except OSError:
+                continue
+            flags = getattr(st, "st_flags", 0) or 0
+            if flags & _UF_HIDDEN:
+                try:
+                    os.chflags(p, flags & ~_UF_HIDDEN)
+                    cleared += 1
+                except OSError:
+                    pass
+    return cleared
+
+
+def _copy_minimal_plugin_tree(plugin_root: Path, dest: Path) -> None:
+    dest.mkdir(parents=True, exist_ok=False)
+    for name in _ESSENTIAL_PLUGIN_SUBDIRS:
+        src_sub = plugin_root / name
+        if src_sub.is_dir():
+            shutil.copytree(src_sub, dest / name, symlinks=False)
+    # ``shutil.copytree`` preserves ``st_flags`` (UF_HIDDEN) via ``copystat``; clear it
+    # on the mirror so Qt's QDir default filter can enumerate the plugins.
+    _clear_hidden_flag_tree(dest)
+
+
+def _posix_platform_libs(platforms_dir: Path) -> list[Path]:
+    if not platforms_dir.is_dir():
+        return []
+    return (
+        sorted(platforms_dir.glob("*.dylib"))
+        + sorted(platforms_dir.glob("*.so"))
+        + sorted(platforms_dir.glob("*.dll"))
+    )
+
+
+def _cache_must_refresh(cache: Path, platform_src_dir: Path) -> bool:
+    """POSIX-based checks avoid relying on QFile for the mirrored cache."""
+
+    cq = cache / "platforms"
+    dst_libs = _posix_platform_libs(cq)
+    src_libs = _posix_platform_libs(platform_src_dir)
+    if not dst_libs:
+        return True
+    markers = ("libqcocoa.dylib", "libqxcb.so", "qwindows.dll")
+    marker_dst = None
+    for name in markers:
+        p = cq / name
+        if p.is_file():
+            marker_dst = p
+            break
+    if marker_dst is None:
+        marker_dst = dst_libs[0]
+    marker_src = None
+    for name in markers:
+        p = platform_src_dir / name
+        if p.is_file():
+            marker_src = p
+            break
+    if marker_src is None:
+        marker_src = src_libs[0] if src_libs else platform_src_dir / marker_dst.name
+    if not marker_src.exists():
+        return True
+    if not marker_dst.exists():
+        return True
+    return marker_src.stat().st_mtime_ns > marker_dst.stat().st_mtime_ns
+
+
+def _effective_plugin_root(plugin_root: Path, platforms_dir: Path) -> Path:
+    """If Qt can't see platform binaries or the plugins root via QFile, mirror a minimal subtree."""
+
+    platforms_ok = _qdir_dylibs_visible(platforms_dir)
+    root_readable = _qdir_any_entries(plugin_root) and _qdir_any_entries(platforms_dir)
+    if platforms_ok and root_readable:
+        return plugin_root
+
+    # PySide6 macOS wheels ship plugin dylibs with ``UF_HIDDEN`` set, which makes
+    # Qt's QDir default filter skip them. Try to clear it in-place first so we
+    # don't have to mirror to a temp dir; fall back to the mirror if chflags
+    # fails (read-only fs) or QDir still can't enumerate.
+    if _clear_hidden_flag_tree(plugin_root):
+        if _qdir_dylibs_visible(platforms_dir) and _qdir_any_entries(plugin_root):
+            return plugin_root
+
+    cache = _plugins_cache_destination(plugin_root)
+
+    if _cache_must_refresh(cache, platforms_dir):
+        if cache.exists():
+            shutil.rmtree(cache)
+        cache.parent.mkdir(parents=True, exist_ok=True)
+        _copy_minimal_plugin_tree(plugin_root, cache)
+    else:
+        # Existing cache could have been mirrored before we knew about UF_HIDDEN.
+        _clear_hidden_flag_tree(cache)
+
+    return cache
+
+
+def apply_qt_plugin_environment() -> None:
+    """Set QT_PLUGIN_PATH to a folder Qt's QFile layer can enumerate; strip empty placeholders."""
+
+    plugin_root = _pyside_plugin_root()
+    if plugin_root is None:
+        return
+
+    for key in ("QT_PLUGIN_PATH", "QT_QPA_PLATFORM_PLUGIN_PATH"):
+        raw = os.environ.get(key)
+        if raw is not None and not str(raw).strip():
+            os.environ.pop(key, None)
+
+    platforms_dir = plugin_root / "platforms"
+    effective = _effective_plugin_root(plugin_root, platforms_dir)
+
+    os.environ["QT_PLUGIN_PATH"] = os.fspath(effective)

--- a/src/ml_pipeline_studio/ui/graph_nodes.py
+++ b/src/ml_pipeline_studio/ui/graph_nodes.py
@@ -129,8 +129,20 @@ class TrainPyTorchNode(BaseNode):
             items=["cnn_small", "mlp_tabular"],
             widget_type=W.QCOMBO_BOX.value,
         )
-        _add_param(self, "epochs", 3, widget_type=W.QSPIN_BOX.value, tooltip="Number of full training passes.")
-        _add_param(self, "batch_size", 32, widget_type=W.QSPIN_BOX.value, tooltip="Samples processed per training step.")
+        _add_param(
+            self,
+            "epochs",
+            3,
+            widget_type=W.QSPIN_BOX.value,
+            tooltip="Number of full training passes.",
+        )
+        _add_param(
+            self,
+            "batch_size",
+            32,
+            widget_type=W.QSPIN_BOX.value,
+            tooltip="Samples processed per training step.",
+        )
         _add_param(
             self,
             "learning_rate",
@@ -158,8 +170,20 @@ class TrainTensorFlowNode(BaseNode):
             items=["cnn_small", "mlp_tabular"],
             widget_type=W.QCOMBO_BOX.value,
         )
-        _add_param(self, "epochs", 3, widget_type=W.QSPIN_BOX.value, tooltip="Number of full training passes.")
-        _add_param(self, "batch_size", 32, widget_type=W.QSPIN_BOX.value, tooltip="Samples processed per training step.")
+        _add_param(
+            self,
+            "epochs",
+            3,
+            widget_type=W.QSPIN_BOX.value,
+            tooltip="Number of full training passes.",
+        )
+        _add_param(
+            self,
+            "batch_size",
+            32,
+            widget_type=W.QSPIN_BOX.value,
+            tooltip="Samples processed per training step.",
+        )
         _add_param(
             self,
             "learning_rate",

--- a/src/ml_pipeline_studio/ui/graph_nodes.py
+++ b/src/ml_pipeline_studio/ui/graph_nodes.py
@@ -8,6 +8,26 @@ from NodeGraphQt import BaseNode
 from NodeGraphQt.constants import NodePropWidgetEnum as W
 
 IDENT = "studio.ml_pipeline.nodes"
+PARAMS_TAB = "Parameters"
+
+
+def _add_param(
+    node: BaseNode,
+    key: str,
+    value: object,
+    *,
+    widget_type: int,
+    tooltip: str,
+    items: list[str] | None = None,
+) -> None:
+    node.create_property(
+        key,
+        value,
+        items=items,
+        widget_type=widget_type,
+        widget_tooltip=tooltip,
+        tab=PARAMS_TAB,
+    )
 
 
 class DatasetNode(BaseNode):
@@ -19,18 +39,49 @@ class DatasetNode(BaseNode):
         super().__init__()
         self.add_output("data")
         self.create_property("pipeline_node_id", str(uuid.uuid4()), widget_type=W.HIDDEN.value)
-        self.create_property(
+        _add_param(
+            self,
             "dataset_mode",
             "image_folder",
+            tooltip="Data source format used by this pipeline.",
             items=["image_folder", "csv_tabular"],
             widget_type=W.QCOMBO_BOX.value,
-            tab="params",
         )
-        self.create_property("data_path", "", widget_type=W.FILE_OPEN.value, tab="params")
-        self.create_property("label_column", "", widget_type=W.QLINE_EDIT.value, tab="params")
-        self.create_property("train_ratio", 0.7, widget_type=W.QDOUBLESPIN_BOX.value, tab="params")
-        self.create_property("val_ratio", 0.15, widget_type=W.QDOUBLESPIN_BOX.value, tab="params")
-        self.create_property("test_ratio", 0.15, widget_type=W.QDOUBLESPIN_BOX.value, tab="params")
+        _add_param(
+            self,
+            "data_path",
+            "",
+            widget_type=W.FILE_OPEN.value,
+            tooltip="Folder or file path for dataset input.",
+        )
+        _add_param(
+            self,
+            "label_column",
+            "",
+            widget_type=W.QLINE_EDIT.value,
+            tooltip="Column name containing class labels (CSV mode only).",
+        )
+        _add_param(
+            self,
+            "train_ratio",
+            0.7,
+            widget_type=W.QDOUBLESPIN_BOX.value,
+            tooltip="Fraction of samples used for training.",
+        )
+        _add_param(
+            self,
+            "val_ratio",
+            0.15,
+            widget_type=W.QDOUBLESPIN_BOX.value,
+            tooltip="Fraction of samples used for validation.",
+        )
+        _add_param(
+            self,
+            "test_ratio",
+            0.15,
+            widget_type=W.QDOUBLESPIN_BOX.value,
+            tooltip="Fraction of samples used for final testing.",
+        )
 
 
 class PreprocessNode(BaseNode):
@@ -43,14 +94,21 @@ class PreprocessNode(BaseNode):
         self.add_input("data")
         self.add_output("data")
         self.create_property("pipeline_node_id", str(uuid.uuid4()), widget_type=W.HIDDEN.value)
-        self.create_property(
+        _add_param(
+            self,
             "preprocess_preset",
             "image_basic",
+            tooltip="Preprocessing recipe to apply before training.",
             items=["image_basic", "passthrough", "tabular_standard", "tabular_standardize"],
             widget_type=W.QCOMBO_BOX.value,
-            tab="params",
         )
-        self.create_property("image_size", 224, widget_type=W.QSPIN_BOX.value, tab="params")
+        _add_param(
+            self,
+            "image_size",
+            224,
+            widget_type=W.QSPIN_BOX.value,
+            tooltip="Target image width and height in pixels.",
+        )
 
 
 class TrainPyTorchNode(BaseNode):
@@ -63,16 +121,23 @@ class TrainPyTorchNode(BaseNode):
         self.add_input("data")
         self.add_output("model")
         self.create_property("pipeline_node_id", str(uuid.uuid4()), widget_type=W.HIDDEN.value)
-        self.create_property(
+        _add_param(
+            self,
             "model_preset",
             "cnn_small",
+            tooltip="Model architecture preset.",
             items=["cnn_small", "mlp_tabular"],
             widget_type=W.QCOMBO_BOX.value,
-            tab="params",
         )
-        self.create_property("epochs", 3, widget_type=W.QSPIN_BOX.value, tab="params")
-        self.create_property("batch_size", 32, widget_type=W.QSPIN_BOX.value, tab="params")
-        self.create_property("learning_rate", 0.001, widget_type=W.QDOUBLESPIN_BOX.value, tab="params")
+        _add_param(self, "epochs", 3, widget_type=W.QSPIN_BOX.value, tooltip="Number of full training passes.")
+        _add_param(self, "batch_size", 32, widget_type=W.QSPIN_BOX.value, tooltip="Samples processed per training step.")
+        _add_param(
+            self,
+            "learning_rate",
+            0.001,
+            widget_type=W.QDOUBLESPIN_BOX.value,
+            tooltip="Optimizer step size for parameter updates.",
+        )
 
 
 class TrainTensorFlowNode(BaseNode):
@@ -85,16 +150,23 @@ class TrainTensorFlowNode(BaseNode):
         self.add_input("data")
         self.add_output("model")
         self.create_property("pipeline_node_id", str(uuid.uuid4()), widget_type=W.HIDDEN.value)
-        self.create_property(
+        _add_param(
+            self,
             "model_preset",
             "cnn_small",
+            tooltip="Model architecture preset.",
             items=["cnn_small", "mlp_tabular"],
             widget_type=W.QCOMBO_BOX.value,
-            tab="params",
         )
-        self.create_property("epochs", 3, widget_type=W.QSPIN_BOX.value, tab="params")
-        self.create_property("batch_size", 32, widget_type=W.QSPIN_BOX.value, tab="params")
-        self.create_property("learning_rate", 0.001, widget_type=W.QDOUBLESPIN_BOX.value, tab="params")
+        _add_param(self, "epochs", 3, widget_type=W.QSPIN_BOX.value, tooltip="Number of full training passes.")
+        _add_param(self, "batch_size", 32, widget_type=W.QSPIN_BOX.value, tooltip="Samples processed per training step.")
+        _add_param(
+            self,
+            "learning_rate",
+            0.001,
+            widget_type=W.QDOUBLESPIN_BOX.value,
+            tooltip="Optimizer step size for parameter updates.",
+        )
 
 
 class EvaluateNode(BaseNode):
@@ -108,12 +180,13 @@ class EvaluateNode(BaseNode):
         self.add_input("data")
         self.add_output("metrics")
         self.create_property("pipeline_node_id", str(uuid.uuid4()), widget_type=W.HIDDEN.value)
-        self.create_property(
+        _add_param(
+            self,
             "eval_split",
             "test",
+            tooltip="Dataset split used to compute metrics.",
             items=["val", "test"],
             widget_type=W.QCOMBO_BOX.value,
-            tab="params",
         )
 
 
@@ -126,7 +199,13 @@ class ValidateNode(BaseNode):
         super().__init__()
         self.add_input("metrics")
         self.create_property("pipeline_node_id", str(uuid.uuid4()), widget_type=W.HIDDEN.value)
-        self.create_property("min_accuracy", 0.5, widget_type=W.QDOUBLESPIN_BOX.value, tab="params")
+        _add_param(
+            self,
+            "min_accuracy",
+            0.5,
+            widget_type=W.QDOUBLESPIN_BOX.value,
+            tooltip="Minimum required accuracy to pass this quality gate.",
+        )
 
 
 class ExportNode(BaseNode):
@@ -138,14 +217,21 @@ class ExportNode(BaseNode):
         super().__init__()
         self.add_input("model")
         self.create_property("pipeline_node_id", str(uuid.uuid4()), widget_type=W.HIDDEN.value)
-        self.create_property(
+        _add_param(
+            self,
             "export_format",
             "pt",
+            tooltip="Serialization format for the trained model.",
             items=["pt", "onnx", "saved_model"],
             widget_type=W.QCOMBO_BOX.value,
-            tab="params",
         )
-        self.create_property("export_path", "", widget_type=W.QLINE_EDIT.value, tab="params")
+        _add_param(
+            self,
+            "export_path",
+            "",
+            widget_type=W.QLINE_EDIT.value,
+            tooltip="Output path for exported model artifacts.",
+        )
 
 
 ALL_STUDIO_NODES = [

--- a/src/ml_pipeline_studio/ui/main_window.py
+++ b/src/ml_pipeline_studio/ui/main_window.py
@@ -7,7 +7,17 @@ from pathlib import Path
 from NodeGraphQt import NodeGraph, PropertiesBinWidget
 from PySide6.QtCore import QObject, Qt, QThread, Signal, Slot
 from PySide6.QtGui import QAction, QKeySequence
-from PySide6.QtWidgets import QDockWidget, QFileDialog, QInputDialog, QMainWindow, QMessageBox, QTextEdit
+from PySide6.QtWidgets import (
+    QDockWidget,
+    QFileDialog,
+    QFrame,
+    QInputDialog,
+    QMainWindow,
+    QMessageBox,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
 
 from ml_pipeline_studio.execution.engine import run_pipeline
 from ml_pipeline_studio.pipeline.document import EdgeRecord, GlobalSettings, NodeRecord, PipelineDocument
@@ -19,6 +29,7 @@ from ml_pipeline_studio.ui.graph_bridge import (
     register_studio_nodes,
 )
 from ml_pipeline_studio.ui.graph_nodes import KIND_TO_NODE_TYPE
+from ml_pipeline_studio.ui.theme import GlassPanelHost, apply_studio_chrome, connect_chrome_refresh
 
 
 def _pytorch_image_template() -> PipelineDocument:
@@ -141,8 +152,9 @@ class _RunWorker(QObject):
 class MainWindow(QMainWindow):
     def __init__(self) -> None:
         super().__init__()
+        self.setObjectName("StudioShell")
         self.setWindowTitle("ML Pipeline Studio")
-        self.resize(1200, 800)
+        self.resize(1280, 820)
 
         self._graph = NodeGraph()
         register_studio_nodes(self._graph)
@@ -150,20 +162,38 @@ class MainWindow(QMainWindow):
         self._current_path: Path | None = None
 
         graph_widget = self._graph.widget
-        self.setCentralWidget(graph_widget)
+        canvas_host = QWidget()
+        canvas_host.setObjectName("CanvasHost")
+        canvas_layout = QVBoxLayout(canvas_host)
+        canvas_layout.setContentsMargins(10, 10, 10, 10)
+        canvas_layout.addWidget(graph_widget)
+        self.setCentralWidget(canvas_host)
 
         self._props = PropertiesBinWidget(node_graph=self._graph)
         dock_p = QDockWidget("Inspector", self)
-        dock_p.setWidget(self._props)
+        dock_p.setAllowedAreas(Qt.DockWidgetArea.AllDockWidgetAreas)
+        dock_p.setFeatures(
+            QDockWidget.DockWidgetFeature.DockWidgetMovable | QDockWidget.DockWidgetFeature.DockWidgetFloatable
+        )
+        dock_p.setWidget(GlassPanelHost(self._props, dock_p))
         self.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, dock_p)
 
         self._log = QTextEdit()
+        self._log.setObjectName("StudioLog")
         self._log.setReadOnly(True)
+        self._log.setFrameShape(QFrame.Shape.NoFrame)
         dock_l = QDockWidget("Run log", self)
-        dock_l.setWidget(self._log)
+        dock_l.setAllowedAreas(Qt.DockWidgetArea.BottomDockWidgetArea | Qt.DockWidgetArea.TopDockWidgetArea)
+        dock_l.setFeatures(
+            QDockWidget.DockWidgetFeature.DockWidgetMovable | QDockWidget.DockWidgetFeature.DockWidgetFloatable
+        )
+        dock_l.setWidget(GlassPanelHost(self._log, dock_l))
         self.addDockWidget(Qt.DockWidgetArea.BottomDockWidgetArea, dock_l)
 
         self._build_menu()
+
+        apply_studio_chrome(self)
+        connect_chrome_refresh(self)
 
         self._thread: QThread | None = None
         self._worker: _RunWorker | None = None

--- a/src/ml_pipeline_studio/ui/main_window.py
+++ b/src/ml_pipeline_studio/ui/main_window.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 
 from NodeGraphQt import NodeGraph, PropertiesBinWidget
-from PySide6.QtCore import QObject, Qt, QThread, Signal, Slot
-from PySide6.QtGui import QAction, QKeySequence
+from PySide6.QtCore import QObject, Qt, QThread, QTimer, Signal, Slot
+from PySide6.QtGui import QAction, QKeySequence, QShowEvent
 from PySide6.QtWidgets import (
     QDockWidget,
     QFileDialog,
@@ -14,6 +14,7 @@ from PySide6.QtWidgets import (
     QInputDialog,
     QMainWindow,
     QMessageBox,
+    QTabWidget,
     QTextEdit,
     QVBoxLayout,
     QWidget,
@@ -29,7 +30,10 @@ from ml_pipeline_studio.ui.graph_bridge import (
     register_studio_nodes,
 )
 from ml_pipeline_studio.ui.graph_nodes import KIND_TO_NODE_TYPE
+from ml_pipeline_studio.ui.terminal_panel import TerminalPanel
 from ml_pipeline_studio.ui.theme import GlassPanelHost, apply_studio_chrome, connect_chrome_refresh
+from ml_pipeline_studio.ui.tutorial_dialog import TutorialDialog
+from ml_pipeline_studio.ui.welcome_dialog import WelcomeDialog
 
 
 def _pytorch_image_template() -> PipelineDocument:
@@ -182,12 +186,17 @@ class MainWindow(QMainWindow):
         self._log.setObjectName("StudioLog")
         self._log.setReadOnly(True)
         self._log.setFrameShape(QFrame.Shape.NoFrame)
+        self._terminal = TerminalPanel()
+        log_tabs = QTabWidget()
+        log_tabs.addTab(self._log, "Run log")
+        log_tabs.addTab(self._terminal, "Terminal")
+
         dock_l = QDockWidget("Run log", self)
         dock_l.setAllowedAreas(Qt.DockWidgetArea.BottomDockWidgetArea | Qt.DockWidgetArea.TopDockWidgetArea)
         dock_l.setFeatures(
             QDockWidget.DockWidgetFeature.DockWidgetMovable | QDockWidget.DockWidgetFeature.DockWidgetFloatable
         )
-        dock_l.setWidget(GlassPanelHost(self._log, dock_l))
+        dock_l.setWidget(GlassPanelHost(log_tabs, dock_l))
         self.addDockWidget(Qt.DockWidgetArea.BottomDockWidgetArea, dock_l)
 
         self._build_menu()
@@ -197,6 +206,22 @@ class MainWindow(QMainWindow):
 
         self._thread: QThread | None = None
         self._worker: _RunWorker | None = None
+        self._welcome_shown = False
+
+    def showEvent(self, event: QShowEvent) -> None:
+        super().showEvent(event)
+        if not self._welcome_shown:
+            self._welcome_shown = True
+            QTimer.singleShot(0, self._show_welcome_dialog)
+
+    def _show_welcome_dialog(self) -> None:
+        dlg = WelcomeDialog(self)
+        dlg.exec()
+        if dlg.choice == "open":
+            self._open()
+        elif dlg.choice == "new":
+            self._new()
+            TutorialDialog(self).exec()
 
     def _build_menu(self) -> None:
         mb = self.menuBar()

--- a/src/ml_pipeline_studio/ui/main_window.py
+++ b/src/ml_pipeline_studio/ui/main_window.py
@@ -152,8 +152,7 @@ class MainWindow(QMainWindow):
         graph_widget = self._graph.widget
         self.setCentralWidget(graph_widget)
 
-        self._props = PropertiesBinWidget()
-        self._props.set_node_graph(self._graph)
+        self._props = PropertiesBinWidget(node_graph=self._graph)
         dock_p = QDockWidget("Inspector", self)
         dock_p.setWidget(self._props)
         self.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, dock_p)

--- a/src/ml_pipeline_studio/ui/terminal_panel.py
+++ b/src/ml_pipeline_studio/ui/terminal_panel.py
@@ -1,0 +1,108 @@
+"""Simple embedded terminal panel for running ad-hoc shell commands."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from PySide6.QtCore import QProcess
+from PySide6.QtWidgets import QHBoxLayout, QLineEdit, QPushButton, QTextEdit, QVBoxLayout, QWidget
+
+
+class TerminalPanel(QWidget):
+    """Lightweight command runner shown beside run logs."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._cwd = Path.cwd()
+        self._proc = QProcess(self)
+        self._proc.readyReadStandardOutput.connect(self._on_stdout)
+        self._proc.readyReadStandardError.connect(self._on_stderr)
+        self._proc.finished.connect(self._on_finished)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(8)
+
+        self._output = QTextEdit(self)
+        self._output.setObjectName("StudioTerminalOutput")
+        self._output.setReadOnly(True)
+        layout.addWidget(self._output, 1)
+
+        controls = QHBoxLayout()
+        controls.setSpacing(8)
+
+        self._input = QLineEdit(self)
+        self._input.setObjectName("StudioTerminalInput")
+        self._input.setPlaceholderText("Run command in project shell (example: ls, pwd, python -m pytest)")
+        self._input.returnPressed.connect(self._execute_command)
+        controls.addWidget(self._input, 1)
+
+        self._run_btn = QPushButton("Run", self)
+        self._run_btn.clicked.connect(self._execute_command)
+        controls.addWidget(self._run_btn)
+
+        self._clear_btn = QPushButton("Clear", self)
+        self._clear_btn.clicked.connect(self._output.clear)
+        controls.addWidget(self._clear_btn)
+
+        layout.addLayout(controls)
+        self._append_line(f"Terminal ready — cwd: {self._cwd}")
+
+    def _append_line(self, text: str) -> None:
+        self._output.append(text)
+
+    def _set_running_state(self, running: bool) -> None:
+        self._run_btn.setEnabled(not running)
+        self._input.setEnabled(not running)
+        if not running:
+            self._input.setFocus()
+
+    def _execute_command(self) -> None:
+        cmd = self._input.text().strip()
+        if not cmd:
+            return
+        self._input.clear()
+
+        if cmd in {"clear", "cls"}:
+            self._output.clear()
+            return
+
+        if cmd.startswith("cd"):
+            self._handle_cd(cmd)
+            return
+
+        if self._proc.state() != QProcess.ProcessState.NotRunning:
+            self._append_line("A command is already running. Please wait.")
+            return
+
+        self._append_line(f"$ {cmd}")
+        self._set_running_state(True)
+        self._proc.setWorkingDirectory(str(self._cwd))
+        self._proc.start("/bin/zsh", ["-lc", cmd])
+
+    def _handle_cd(self, cmd: str) -> None:
+        parts = cmd.split(maxsplit=1)
+        target = parts[1] if len(parts) > 1 else "~"
+        expanded = Path(os.path.expanduser(target))
+        next_dir = expanded if expanded.is_absolute() else (self._cwd / expanded)
+        next_dir = next_dir.resolve()
+        if not next_dir.exists() or not next_dir.is_dir():
+            self._append_line(f"cd: no such directory: {target}")
+            return
+        self._cwd = next_dir
+        self._append_line(f"cwd -> {self._cwd}")
+
+    def _on_stdout(self) -> None:
+        data = bytes(self._proc.readAllStandardOutput()).decode(errors="replace")
+        if data:
+            self._append_line(data.rstrip("\n"))
+
+    def _on_stderr(self) -> None:
+        data = bytes(self._proc.readAllStandardError()).decode(errors="replace")
+        if data:
+            self._append_line(data.rstrip("\n"))
+
+    def _on_finished(self, code: int, _status: QProcess.ExitStatus) -> None:
+        self._append_line(f"[exit {code}]")
+        self._set_running_state(False)

--- a/src/ml_pipeline_studio/ui/theme.py
+++ b/src/ml_pipeline_studio/ui/theme.py
@@ -21,51 +21,55 @@ def _is_dark_color_scheme() -> bool:
 
 
 def build_studio_stylesheet(*, dark: bool) -> str:
-    """Stylesheet for QMainWindow#StudioShell — scoped object names; avoids the node graph."""
+    """Stylesheet for QMainWindow#StudioShell in a clean VS Code-inspired look."""
     if dark:
-        shell_a, shell_b = "#14161c", "#0a0b0e"
-        canvas_a, canvas_b = "#161820", "#0d0f14"
-        dock_title_bg = "rgba(255, 255, 255, 0.08)"
-        dock_title_fg = "#f2f4f8"
-        glass_bg = "rgba(38, 42, 54, 0.72)"
-        glass_border = "rgba(255, 255, 255, 0.14)"
-        glass_rim = "rgba(255, 255, 255, 0.06)"
-        text = "#e8eaef"
-        muted = "#9aa3b2"
-        log_bg = "rgba(12, 14, 18, 0.55)"
-        log_fg = "#d6dae3"
-        selection = "rgba(99, 139, 255, 0.45)"
-        inner_surface = "rgba(22, 24, 32, 0.85)"
-        grid = "rgba(255, 255, 255, 0.08)"
-        header_bg = "rgba(255, 255, 255, 0.06)"
-        btn_bg = "rgba(255, 255, 255, 0.08)"
-        btn_border = "rgba(255, 255, 255, 0.14)"
-        btn_hover = "rgba(255, 255, 255, 0.14)"
-        spin_bg = "rgba(255, 255, 255, 0.06)"
-        tab_bg = "rgba(255, 255, 255, 0.04)"
-        tab_sel = "rgba(255, 255, 255, 0.12)"
+        shell_a, shell_b = "#1f1f1f", "#1b1b1b"
+        canvas_a, canvas_b = "#252526", "#1e1e1e"
+        dock_title_bg = "#252526"
+        dock_title_fg = "#cccccc"
+        panel_bg = "#252526"
+        panel_border = "#3c3c3c"
+        panel_inner_border = "#2a2d2e"
+        text = "#d4d4d4"
+        muted = "#9da0a3"
+        log_bg = "#1e1e1e"
+        log_fg = "#d4d4d4"
+        selection = "rgba(38, 79, 120, 0.65)"
+        inner_surface = "#1e1e1e"
+        grid = "#313131"
+        header_bg = "#252526"
+        btn_bg = "#2d2d30"
+        btn_border = "#3f3f46"
+        btn_hover = "#37373d"
+        field_bg = "#3c3c3c"
+        field_border = "#55585c"
+        focus_border = "#007acc"
+        tab_bg = "#2d2d30"
+        tab_sel = "#1e1e1e"
     else:
-        shell_a, shell_b = "#e4e8f0", "#d6dce8"
-        canvas_a, canvas_b = "#e8ecf4", "#dde3ee"
-        dock_title_bg = "rgba(255, 255, 255, 0.55)"
-        dock_title_fg = "#1a1d26"
-        glass_bg = "rgba(255, 255, 255, 0.52)"
-        glass_border = "rgba(255, 255, 255, 0.85)"
-        glass_rim = "rgba(255, 255, 255, 0.35)"
-        text = "#1c1f28"
-        muted = "#5c6578"
-        log_bg = "rgba(255, 255, 255, 0.45)"
-        log_fg = "#242832"
-        selection = "rgba(64, 120, 255, 0.35)"
-        inner_surface = "rgba(255, 255, 255, 0.72)"
-        grid = "rgba(0, 0, 0, 0.08)"
-        header_bg = "rgba(255, 255, 255, 0.65)"
-        btn_bg = "rgba(255, 255, 255, 0.72)"
-        btn_border = "rgba(0, 0, 0, 0.08)"
-        btn_hover = "rgba(255, 255, 255, 0.92)"
-        spin_bg = "rgba(255, 255, 255, 0.55)"
-        tab_bg = "rgba(255, 255, 255, 0.35)"
-        tab_sel = "rgba(255, 255, 255, 0.75)"
+        shell_a, shell_b = "#f3f3f3", "#ececec"
+        canvas_a, canvas_b = "#ffffff", "#f3f3f3"
+        dock_title_bg = "#f3f3f3"
+        dock_title_fg = "#2d2d2d"
+        panel_bg = "#f3f3f3"
+        panel_border = "#d0d0d0"
+        panel_inner_border = "#e3e3e3"
+        text = "#1f1f1f"
+        muted = "#5e5e5e"
+        log_bg = "#ffffff"
+        log_fg = "#1f1f1f"
+        selection = "rgba(173, 214, 255, 0.55)"
+        inner_surface = "#ffffff"
+        grid = "#e5e5e5"
+        header_bg = "#f6f6f6"
+        btn_bg = "#ececec"
+        btn_border = "#d0d0d0"
+        btn_hover = "#e2e2e2"
+        field_bg = "#ffffff"
+        field_border = "#cccccc"
+        focus_border = "#006fc9"
+        tab_bg = "#ececec"
+        tab_sel = "#ffffff"
 
     return f"""
 QMainWindow#StudioShell {{
@@ -85,33 +89,41 @@ QDockWidget::title {{
   text-align: left;
   background-color: {dock_title_bg};
   color: {dock_title_fg};
-  padding: 11px 16px;
-  border-top-left-radius: 16px;
-  border-top-right-radius: 16px;
+  padding: 8px 12px;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
   font-weight: 600;
-  font-size: 13px;
-  border: 1px solid {glass_rim};
+  font-size: 12px;
+  border: 1px solid {panel_border};
   border-bottom: none;
 }}
 
 QFrame#GlassPanelHost {{
-  background-color: {glass_bg};
-  border: 1px solid {glass_border};
-  border-radius: 20px;
+  background-color: {panel_bg};
+  border: 1px solid {panel_border};
+  border-radius: 8px;
 }}
 
-QTextEdit#StudioLog {{
+QTextEdit#StudioLog,
+QTextEdit#StudioTerminalOutput {{
   background-color: {log_bg};
   color: {log_fg};
-  border: 1px solid {glass_rim};
-  border-radius: 14px;
-  padding: 12px 14px;
-  font-family: "SF Mono", "Menlo", "Monaco", "Consolas", monospace;
+  border: 1px solid {panel_inner_border};
+  border-radius: 6px;
+  padding: 10px 12px;
+  font-family: "Menlo", "Monaco", "Consolas", "Courier New", monospace;
   font-size: 12px;
   selection-background-color: {selection};
 }}
 
 QFrame#GlassPanelHost QLabel {{
+  color: {text};
+  font-size: 12px;
+  font-weight: 500;
+}}
+
+QFrame#GlassPanelHost QTabWidget,
+QFrame#GlassPanelHost QWidget {{
   color: {text};
 }}
 
@@ -119,12 +131,19 @@ QFrame#GlassPanelHost QLineEdit,
 QFrame#GlassPanelHost QSpinBox,
 QFrame#GlassPanelHost QDoubleSpinBox,
 QFrame#GlassPanelHost QComboBox {{
-  background-color: {spin_bg};
+  background-color: {field_bg};
   color: {text};
-  border: 1px solid {glass_border};
-  border-radius: 8px;
-  padding: 6px 10px;
+  border: 1px solid {field_border};
+  border-radius: 4px;
+  padding: 5px 8px;
   min-height: 18px;
+}}
+
+QFrame#GlassPanelHost QLineEdit:focus,
+QFrame#GlassPanelHost QSpinBox:focus,
+QFrame#GlassPanelHost QDoubleSpinBox:focus,
+QFrame#GlassPanelHost QComboBox:focus {{
+  border: 1px solid {focus_border};
 }}
 
 QFrame#GlassPanelHost QComboBox::drop-down {{
@@ -137,8 +156,8 @@ QFrame#GlassPanelHost QTableWidget {{
   alternate-background-color: {inner_surface};
   color: {text};
   gridline-color: {grid};
-  border: none;
-  border-radius: 12px;
+  border: 1px solid {panel_inner_border};
+  border-radius: 6px;
 }}
 
 QFrame#GlassPanelHost QTableWidget::item {{
@@ -162,8 +181,8 @@ QFrame#GlassPanelHost QPushButton {{
   background-color: {btn_bg};
   color: {text};
   border: 1px solid {btn_border};
-  border-radius: 10px;
-  padding: 7px 14px;
+  border-radius: 4px;
+  padding: 6px 12px;
   font-weight: 500;
 }}
 
@@ -172,19 +191,21 @@ QFrame#GlassPanelHost QPushButton:hover {{
 }}
 
 QFrame#GlassPanelHost QTabWidget::pane {{
-  border: 1px solid {glass_rim};
-  border-radius: 12px;
+  border: 1px solid {panel_inner_border};
+  border-radius: 6px;
   background: {inner_surface};
-  top: -1px;
+  top: 0;
 }}
 
 QFrame#GlassPanelHost QTabBar::tab {{
   background: {tab_bg};
   color: {muted};
-  padding: 8px 16px;
-  margin-right: 4px;
-  border-top-left-radius: 10px;
-  border-top-right-radius: 10px;
+  padding: 6px 12px;
+  margin-right: 2px;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+  border: 1px solid {panel_inner_border};
+  border-bottom: none;
 }}
 
 QFrame#GlassPanelHost QTabBar::tab:selected {{
@@ -231,8 +252,158 @@ QFrame#GlassPanelHost QScrollBar::sub-line:horizontal {{
 QFrame#GlassPanelHost QTreeWidget {{
   background-color: {inner_surface};
   color: {text};
+  border: 1px solid {panel_inner_border};
+  border-radius: 6px;
+}}
+
+QFrame#GlassPanelHost QGroupBox {{
+  border: 1px solid {panel_inner_border};
+  border-radius: 6px;
+  margin-top: 12px;
+  padding-top: 10px;
+  background: {inner_surface};
+}}
+
+QFrame#GlassPanelHost QGroupBox::title {{
+  subcontrol-origin: margin;
+  left: 10px;
+  padding: 0 4px;
+  color: {muted};
+  font-weight: 600;
+  font-size: 11px;
+}}
+
+QMenuBar {{
+  background: {shell_a};
+  color: {text};
+  border-bottom: 1px solid {panel_border};
+}}
+
+QMenuBar::item {{
+  padding: 6px 10px;
+  background: transparent;
+}}
+
+QMenuBar::item:selected {{
+  background: {btn_bg};
+  border-radius: 4px;
+}}
+
+QMenu {{
+  background: {panel_bg};
+  color: {text};
+  border: 1px solid {panel_border};
+}}
+
+QMenu::item:selected {{
+  background: {selection};
+}}
+"""
+
+
+def build_welcome_dialog_stylesheet(*, dark: bool) -> str:
+    """Styles for QDialog#WelcomeDialog — matches studio glass tokens."""
+    if dark:
+        shell_a, shell_b = "#14161c", "#0a0b0e"
+        text = "#e8eaef"
+        muted = "#9aa3b2"
+        glass_bg = "rgba(38, 42, 54, 0.88)"
+        glass_border = "rgba(255, 255, 255, 0.14)"
+        card_rest = "rgba(255, 255, 255, 0.06)"
+        card_hover = "rgba(99, 139, 255, 0.18)"
+        card_border_rest = "rgba(255, 255, 255, 0.12)"
+        card_border_hover = "rgba(118, 160, 255, 0.55)"
+        accent = "#93b4ff"
+        skip_fg = "#8b95a8"
+        skip_hover_fg = "#c8ced9"
+    else:
+        shell_a, shell_b = "#e8ecf8", "#d8dfea"
+        text = "#1c1f28"
+        muted = "#5c6578"
+        glass_bg = "rgba(255, 255, 255, 0.78)"
+        glass_border = "rgba(255, 255, 255, 0.9)"
+        card_rest = "rgba(255, 255, 255, 0.72)"
+        card_hover = "rgba(64, 120, 255, 0.12)"
+        card_border_rest = "rgba(0, 0, 0, 0.08)"
+        card_border_hover = "rgba(64, 120, 255, 0.45)"
+        accent = "#2d62f0"
+        skip_fg = "#6b7486"
+        skip_hover_fg = "#2a3140"
+
+    return f"""
+QDialog#WelcomeDialog {{
+  background-color: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 {shell_a}, stop:1 {shell_b});
+}}
+
+QFrame#WelcomePanel {{
+  background-color: {glass_bg};
+  border: 1px solid {glass_border};
+  border-radius: 24px;
+}}
+
+QLabel#WelcomeTitle {{
+  color: {text};
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.3px;
+}}
+
+QLabel#WelcomeSubtitle {{
+  color: {muted};
+  font-size: 14px;
+  font-weight: 400;
+}}
+
+QFrame#WelcomeCard {{
+  background-color: {card_rest};
+  border: 1px solid {card_border_rest};
+  border-radius: 16px;
+}}
+
+QFrame#WelcomeCard:hover {{
+  background-color: {card_hover};
+  border-color: {card_border_hover};
+}}
+
+QFrame#WelcomeCard:focus {{
+  border-color: {card_border_hover};
+}}
+
+QLabel#WelcomeCardHint {{
+  color: {muted};
+  font-size: 13px;
+  font-weight: 400;
+}}
+
+QLabel#WelcomeAccent {{
+  color: {accent};
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}}
+
+QLabel#WelcomeCardHeading {{
+  color: {text};
+  font-size: 16px;
+  font-weight: 700;
+}}
+
+QPushButton#WelcomeSkip {{
+  background: transparent;
   border: none;
-  border-radius: 10px;
+  color: {skip_fg};
+  font-size: 13px;
+  font-weight: 500;
+  padding: 10px;
+}}
+
+QPushButton#WelcomeSkip:hover {{
+  color: {skip_hover_fg};
+}}
+
+QPushButton#WelcomeSkip:pressed {{
+  color: {text};
 }}
 """
 
@@ -271,5 +442,20 @@ def connect_chrome_refresh(window: QMainWindow) -> None:
 
     def _refresh(_scheme: Qt.ColorScheme | None = None) -> None:
         apply_studio_chrome(window)
+
+    hints.colorSchemeChanged.connect(_refresh)
+
+
+def apply_welcome_dialog_chrome(dialog: QWidget) -> None:
+    """Apply or refresh welcome dialog styles (system light/dark)."""
+    dark = _is_dark_color_scheme()
+    dialog.setStyleSheet(build_welcome_dialog_stylesheet(dark=dark))
+
+
+def connect_welcome_dialog_chrome(dialog: QWidget) -> None:
+    hints = QGuiApplication.styleHints()
+
+    def _refresh(_scheme: Qt.ColorScheme | None = None) -> None:
+        apply_welcome_dialog_chrome(dialog)
 
     hints.colorSchemeChanged.connect(_refresh)

--- a/src/ml_pipeline_studio/ui/theme.py
+++ b/src/ml_pipeline_studio/ui/theme.py
@@ -1,0 +1,275 @@
+"""Liquid-glass inspired chrome: frosted panels, system-aware light/dark tokens."""
+
+from __future__ import annotations
+
+import sys
+
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QGuiApplication, QPalette
+from PySide6.QtWidgets import QApplication, QFrame, QMainWindow, QVBoxLayout, QWidget
+
+
+def _is_dark_color_scheme() -> bool:
+    hints = QGuiApplication.styleHints()
+    scheme = hints.colorScheme()
+    if scheme == Qt.ColorScheme.Dark:
+        return True
+    if scheme == Qt.ColorScheme.Light:
+        return False
+    win = QGuiApplication.palette().color(QPalette.ColorRole.Window)
+    return win.lightness() < 128
+
+
+def build_studio_stylesheet(*, dark: bool) -> str:
+    """Stylesheet for QMainWindow#StudioShell — scoped object names; avoids the node graph."""
+    if dark:
+        shell_a, shell_b = "#14161c", "#0a0b0e"
+        canvas_a, canvas_b = "#161820", "#0d0f14"
+        dock_title_bg = "rgba(255, 255, 255, 0.08)"
+        dock_title_fg = "#f2f4f8"
+        glass_bg = "rgba(38, 42, 54, 0.72)"
+        glass_border = "rgba(255, 255, 255, 0.14)"
+        glass_rim = "rgba(255, 255, 255, 0.06)"
+        text = "#e8eaef"
+        muted = "#9aa3b2"
+        log_bg = "rgba(12, 14, 18, 0.55)"
+        log_fg = "#d6dae3"
+        selection = "rgba(99, 139, 255, 0.45)"
+        inner_surface = "rgba(22, 24, 32, 0.85)"
+        grid = "rgba(255, 255, 255, 0.08)"
+        header_bg = "rgba(255, 255, 255, 0.06)"
+        btn_bg = "rgba(255, 255, 255, 0.08)"
+        btn_border = "rgba(255, 255, 255, 0.14)"
+        btn_hover = "rgba(255, 255, 255, 0.14)"
+        spin_bg = "rgba(255, 255, 255, 0.06)"
+        tab_bg = "rgba(255, 255, 255, 0.04)"
+        tab_sel = "rgba(255, 255, 255, 0.12)"
+    else:
+        shell_a, shell_b = "#e4e8f0", "#d6dce8"
+        canvas_a, canvas_b = "#e8ecf4", "#dde3ee"
+        dock_title_bg = "rgba(255, 255, 255, 0.55)"
+        dock_title_fg = "#1a1d26"
+        glass_bg = "rgba(255, 255, 255, 0.52)"
+        glass_border = "rgba(255, 255, 255, 0.85)"
+        glass_rim = "rgba(255, 255, 255, 0.35)"
+        text = "#1c1f28"
+        muted = "#5c6578"
+        log_bg = "rgba(255, 255, 255, 0.45)"
+        log_fg = "#242832"
+        selection = "rgba(64, 120, 255, 0.35)"
+        inner_surface = "rgba(255, 255, 255, 0.72)"
+        grid = "rgba(0, 0, 0, 0.08)"
+        header_bg = "rgba(255, 255, 255, 0.65)"
+        btn_bg = "rgba(255, 255, 255, 0.72)"
+        btn_border = "rgba(0, 0, 0, 0.08)"
+        btn_hover = "rgba(255, 255, 255, 0.92)"
+        spin_bg = "rgba(255, 255, 255, 0.55)"
+        tab_bg = "rgba(255, 255, 255, 0.35)"
+        tab_sel = "rgba(255, 255, 255, 0.75)"
+
+    return f"""
+QMainWindow#StudioShell {{
+  background-color: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 {shell_a}, stop:1 {shell_b});
+}}
+
+QWidget#CanvasHost {{
+  background-color: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 {canvas_a}, stop:1 {canvas_b});
+}}
+
+QDockWidget {{
+  background: transparent;
+  border: none;
+}}
+
+QDockWidget::title {{
+  text-align: left;
+  background-color: {dock_title_bg};
+  color: {dock_title_fg};
+  padding: 11px 16px;
+  border-top-left-radius: 16px;
+  border-top-right-radius: 16px;
+  font-weight: 600;
+  font-size: 13px;
+  border: 1px solid {glass_rim};
+  border-bottom: none;
+}}
+
+QFrame#GlassPanelHost {{
+  background-color: {glass_bg};
+  border: 1px solid {glass_border};
+  border-radius: 20px;
+}}
+
+QTextEdit#StudioLog {{
+  background-color: {log_bg};
+  color: {log_fg};
+  border: 1px solid {glass_rim};
+  border-radius: 14px;
+  padding: 12px 14px;
+  font-family: "SF Mono", "Menlo", "Monaco", "Consolas", monospace;
+  font-size: 12px;
+  selection-background-color: {selection};
+}}
+
+QFrame#GlassPanelHost QLabel {{
+  color: {text};
+}}
+
+QFrame#GlassPanelHost QLineEdit,
+QFrame#GlassPanelHost QSpinBox,
+QFrame#GlassPanelHost QDoubleSpinBox,
+QFrame#GlassPanelHost QComboBox {{
+  background-color: {spin_bg};
+  color: {text};
+  border: 1px solid {glass_border};
+  border-radius: 8px;
+  padding: 6px 10px;
+  min-height: 18px;
+}}
+
+QFrame#GlassPanelHost QComboBox::drop-down {{
+  border: none;
+  width: 22px;
+}}
+
+QFrame#GlassPanelHost QTableWidget {{
+  background-color: {inner_surface};
+  alternate-background-color: {inner_surface};
+  color: {text};
+  gridline-color: {grid};
+  border: none;
+  border-radius: 12px;
+}}
+
+QFrame#GlassPanelHost QTableWidget::item {{
+  padding: 6px;
+}}
+
+QFrame#GlassPanelHost QTableWidget::item:selected {{
+  background-color: {selection};
+}}
+
+QFrame#GlassPanelHost QHeaderView::section {{
+  background-color: {header_bg};
+  color: {text};
+  padding: 8px;
+  border: none;
+  border-bottom: 1px solid {grid};
+  font-weight: 600;
+}}
+
+QFrame#GlassPanelHost QPushButton {{
+  background-color: {btn_bg};
+  color: {text};
+  border: 1px solid {btn_border};
+  border-radius: 10px;
+  padding: 7px 14px;
+  font-weight: 500;
+}}
+
+QFrame#GlassPanelHost QPushButton:hover {{
+  background-color: {btn_hover};
+}}
+
+QFrame#GlassPanelHost QTabWidget::pane {{
+  border: 1px solid {glass_rim};
+  border-radius: 12px;
+  background: {inner_surface};
+  top: -1px;
+}}
+
+QFrame#GlassPanelHost QTabBar::tab {{
+  background: {tab_bg};
+  color: {muted};
+  padding: 8px 16px;
+  margin-right: 4px;
+  border-top-left-radius: 10px;
+  border-top-right-radius: 10px;
+}}
+
+QFrame#GlassPanelHost QTabBar::tab:selected {{
+  background: {tab_sel};
+  color: {text};
+  font-weight: 600;
+}}
+
+QFrame#GlassPanelHost QScrollBar:vertical {{
+  width: 11px;
+  background: transparent;
+  margin: 4px 2px 4px 0;
+  border-radius: 5px;
+}}
+
+QFrame#GlassPanelHost QScrollBar::handle:vertical {{
+  background: {btn_border};
+  border-radius: 5px;
+  min-height: 36px;
+}}
+
+QFrame#GlassPanelHost QScrollBar::add-line:vertical,
+QFrame#GlassPanelHost QScrollBar::sub-line:vertical {{
+  height: 0;
+}}
+
+QFrame#GlassPanelHost QScrollBar:horizontal {{
+  height: 11px;
+  background: transparent;
+  margin: 0 4px 2px 4px;
+}}
+
+QFrame#GlassPanelHost QScrollBar::handle:horizontal {{
+  background: {btn_border};
+  border-radius: 5px;
+  min-width: 36px;
+}}
+
+QFrame#GlassPanelHost QScrollBar::add-line:horizontal,
+QFrame#GlassPanelHost QScrollBar::sub-line:horizontal {{
+  width: 0;
+}}
+
+QFrame#GlassPanelHost QTreeWidget {{
+  background-color: {inner_surface};
+  color: {text};
+  border: none;
+  border-radius: 10px;
+}}
+"""
+
+
+class GlassPanelHost(QFrame):
+    """Rounded frosted container for dock content (inspector, log)."""
+
+    def __init__(self, inner: QWidget, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setObjectName("GlassPanelHost")
+        lay = QVBoxLayout(self)
+        lay.setContentsMargins(14, 14, 14, 14)
+        lay.setSpacing(0)
+        lay.addWidget(inner, 1)
+
+
+def configure_application_font(app: QApplication) -> None:
+    from PySide6.QtGui import QFont
+
+    if sys.platform == "darwin":
+        font = QFont(".AppleSystemUIFont", 13)
+    else:
+        font = QFont()
+        font.setPointSize(10)
+    app.setFont(font)
+
+
+def apply_studio_chrome(window: QMainWindow) -> None:
+    """Apply or refresh glass chrome for the main window (call after widgets exist)."""
+    dark = _is_dark_color_scheme()
+    window.setStyleSheet(build_studio_stylesheet(dark=dark))
+
+
+def connect_chrome_refresh(window: QMainWindow) -> None:
+    hints = QGuiApplication.styleHints()
+
+    def _refresh(_scheme: Qt.ColorScheme | None = None) -> None:
+        apply_studio_chrome(window)
+
+    hints.colorSchemeChanged.connect(_refresh)

--- a/src/ml_pipeline_studio/ui/tutorial_dialog.py
+++ b/src/ml_pipeline_studio/ui/tutorial_dialog.py
@@ -1,0 +1,167 @@
+"""Step-by-step first-run tutorial shown after creating a new file."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QDialog,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QStackedWidget,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ml_pipeline_studio.ui.theme import apply_welcome_dialog_chrome, connect_welcome_dialog_chrome
+
+
+@dataclass(frozen=True)
+class TutorialStep:
+    title: str
+    body: str
+
+
+_STEPS: tuple[TutorialStep, ...] = (
+    TutorialStep(
+        "1. Build your pipeline graph",
+        "Use Add node in the menu bar to insert Dataset, Preprocess, Train, "
+        "Evaluate, and Export nodes. Drag nodes on the canvas to arrange the flow "
+        "left-to-right.",
+    ),
+    TutorialStep(
+        "2. Connect nodes in order",
+        "Create links by dragging from an output port (right side) to a compatible "
+        "input port (left side) on the next node. A valid chain is usually "
+        "Dataset -> Preprocess -> Train -> Evaluate/Export.",
+    ),
+    TutorialStep(
+        "3. Configure every node in Inspector",
+        "Click a node on the canvas and use the Inspector panel on the right. "
+        "Open the Parameters tab and edit each field with clear labels "
+        "(for example: Data Path, Batch Size, Learning Rate). Changes save directly "
+        "to the selected node.",
+    ),
+    TutorialStep(
+        "4. Inspector tips that matter",
+        "Use the top controls in Inspector: the number box is how many selected "
+        "nodes show at once, Lock freezes the current view, and Clear removes nodes "
+        "from the panel. Hover field labels for extra help text and expected values.",
+    ),
+    TutorialStep(
+        "5. Validate, run, and save",
+        "Use Run -> Run pipeline (Ctrl+R) to validate and execute. Read progress in "
+        "Run log, then save with File -> Save or Save As to store your pipeline JSON.",
+    ),
+)
+
+
+class TutorialDialog(QDialog):
+    """Guided onboarding tutorial for first-time blank-canvas users."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setObjectName("WelcomeDialog")
+        self.setWindowTitle("How to use this app")
+        self.setModal(True)
+        self.resize(620, 430)
+        self.setMinimumSize(560, 390)
+
+        apply_welcome_dialog_chrome(self)
+        connect_welcome_dialog_chrome(self)
+
+        root = QVBoxLayout(self)
+        root.setContentsMargins(28, 28, 28, 24)
+        root.setSpacing(0)
+
+        panel = QFrame()
+        panel.setObjectName("WelcomePanel")
+        root.addWidget(panel)
+
+        lay = QVBoxLayout(panel)
+        lay.setContentsMargins(24, 24, 24, 20)
+        lay.setSpacing(14)
+
+        title = QLabel("How to use ML Pipeline Studio")
+        title.setObjectName("WelcomeTitle")
+        lay.addWidget(title)
+
+        subtitle = QLabel("A quick guided walkthrough for your new file.")
+        subtitle.setObjectName("WelcomeSubtitle")
+        lay.addWidget(subtitle)
+
+        self._step_label = QLabel("")
+        self._step_label.setObjectName("WelcomeAccent")
+        lay.addWidget(self._step_label)
+
+        self._stack = QStackedWidget()
+        self._stack.setMinimumHeight(200)
+        lay.addWidget(self._stack, 1)
+
+        for step in _STEPS:
+            page = QWidget()
+            page_lay = QVBoxLayout(page)
+            page_lay.setContentsMargins(0, 0, 0, 0)
+            page_lay.setSpacing(8)
+
+            heading = QLabel(step.title)
+            heading.setObjectName("WelcomeCardHeading")
+            heading.setWordWrap(True)
+
+            body = QLabel(step.body)
+            body.setObjectName("WelcomeCardHint")
+            body.setWordWrap(True)
+            body.setTextInteractionFlags(
+                Qt.TextInteractionFlag.TextSelectableByMouse | Qt.TextInteractionFlag.LinksAccessibleByMouse
+            )
+
+            page_lay.addWidget(heading)
+            page_lay.addWidget(body)
+            page_lay.addStretch(1)
+            self._stack.addWidget(page)
+
+        controls = QHBoxLayout()
+        controls.setSpacing(8)
+
+        self._btn_back = QPushButton("Back")
+        self._btn_back.setAutoDefault(False)
+        self._btn_back.clicked.connect(self._go_back)
+
+        self._btn_next = QPushButton("Next")
+        self._btn_next.setAutoDefault(True)
+        self._btn_next.clicked.connect(self._go_next)
+
+        self._btn_done = QPushButton("Start building")
+        self._btn_done.setAutoDefault(False)
+        self._btn_done.clicked.connect(self.accept)
+
+        controls.addWidget(self._btn_back)
+        controls.addStretch(1)
+        controls.addWidget(self._btn_next)
+        controls.addWidget(self._btn_done)
+        lay.addLayout(controls)
+
+        self._refresh_controls()
+
+    def _go_back(self) -> None:
+        idx = self._stack.currentIndex()
+        if idx > 0:
+            self._stack.setCurrentIndex(idx - 1)
+            self._refresh_controls()
+
+    def _go_next(self) -> None:
+        idx = self._stack.currentIndex()
+        if idx < self._stack.count() - 1:
+            self._stack.setCurrentIndex(idx + 1)
+            self._refresh_controls()
+
+    def _refresh_controls(self) -> None:
+        idx = self._stack.currentIndex()
+        total = self._stack.count()
+        self._step_label.setText(f"Step {idx + 1} of {total}")
+        self._btn_back.setEnabled(idx > 0)
+        self._btn_next.setVisible(idx < total - 1)
+        self._btn_done.setVisible(idx == total - 1)

--- a/src/ml_pipeline_studio/ui/welcome_dialog.py
+++ b/src/ml_pipeline_studio/ui/welcome_dialog.py
@@ -1,0 +1,157 @@
+"""Modal welcome dialog: open an existing pipeline or start a new one."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from PySide6.QtCore import Qt, Signal
+from PySide6.QtGui import QKeyEvent, QMouseEvent
+from PySide6.QtWidgets import (
+    QDialog,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QSizePolicy,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ml_pipeline_studio.ui.theme import apply_welcome_dialog_chrome, connect_welcome_dialog_chrome
+
+WelcomeChoice = Literal["open", "new", "skip"]
+
+
+class ChoiceCard(QFrame):
+    clicked = Signal()
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setObjectName("WelcomeCard")
+        self.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.setFocusPolicy(Qt.FocusPolicy.StrongFocus | Qt.FocusPolicy.TabFocus)
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.MinimumExpanding)
+        self.setMinimumHeight(130)
+
+    def mousePressEvent(self, event: QMouseEvent) -> None:
+        if event.button() == Qt.MouseButton.LeftButton:
+            self.clicked.emit()
+        super().mousePressEvent(event)
+
+    def keyPressEvent(self, event: QKeyEvent) -> None:
+        k = event.key()
+        if k in (Qt.Key.Key_Return, Qt.Key.Key_Enter, Qt.Key.Key_Space):
+            self.clicked.emit()
+            event.accept()
+            return
+        super().keyPressEvent(event)
+
+
+class WelcomeDialog(QDialog):
+    """Glass-panel welcome screen: open saved pipeline, blank canvas, or dismiss."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setObjectName("WelcomeDialog")
+        self.setWindowTitle("Welcome")
+        self.setModal(True)
+        self.resize(492, 404)
+        self.setMinimumWidth(400)
+
+        apply_welcome_dialog_chrome(self)
+        connect_welcome_dialog_chrome(self)
+
+        self._choice: WelcomeChoice = "skip"
+
+        root = QVBoxLayout(self)
+        root.setContentsMargins(28, 28, 28, 24)
+        root.setSpacing(0)
+
+        panel = QFrame()
+        panel.setObjectName("WelcomePanel")
+        root.addWidget(panel)
+        lay = QVBoxLayout(panel)
+        lay.setContentsMargins(28, 28, 28, 24)
+        lay.setSpacing(20)
+
+        title = QLabel("ML Pipeline Studio")
+        title.setObjectName("WelcomeTitle")
+
+        subtitle = QLabel("Open a saved pipeline or start from a blank canvas.")
+        subtitle.setObjectName("WelcomeSubtitle")
+        subtitle.setWordWrap(True)
+
+        lay.addWidget(title)
+        lay.addWidget(subtitle)
+        lay.addSpacing(4)
+
+        row = QHBoxLayout()
+        row.setSpacing(14)
+
+        self._card_open = ChoiceCard(self)
+        open_lay = QVBoxLayout(self._card_open)
+        open_lay.setSpacing(8)
+        open_lay.setContentsMargins(20, 18, 20, 18)
+        open_accent = QLabel("Open")
+        open_accent.setObjectName("WelcomeAccent")
+        open_heading = QLabel("Existing pipeline")
+        open_heading.setObjectName("WelcomeCardHeading")
+        open_hint = QLabel("Browse and load a .json pipeline from disk.")
+        open_hint.setObjectName("WelcomeCardHint")
+        open_hint.setWordWrap(True)
+        open_lay.addWidget(open_accent)
+        open_lay.addWidget(open_heading)
+        open_lay.addWidget(open_hint)
+        open_lay.addStretch()
+        self._card_open.clicked.connect(self._on_open)
+
+        self._card_new = ChoiceCard(self)
+        new_lay = QVBoxLayout(self._card_new)
+        new_lay.setSpacing(8)
+        new_lay.setContentsMargins(20, 18, 20, 18)
+        new_accent = QLabel("New")
+        new_accent.setObjectName("WelcomeAccent")
+        new_heading = QLabel("Blank canvas")
+        new_heading.setObjectName("WelcomeCardHeading")
+        new_hint = QLabel("Start fresh and sketch a pipeline from scratch.")
+        new_hint.setObjectName("WelcomeCardHint")
+        new_hint.setWordWrap(True)
+        new_lay.addWidget(new_accent)
+        new_lay.addWidget(new_heading)
+        new_lay.addWidget(new_hint)
+        new_lay.addStretch()
+        self._card_new.clicked.connect(self._on_new)
+
+        row.addWidget(self._card_open, 1)
+        row.addWidget(self._card_new, 1)
+        lay.addLayout(row)
+
+        skip = QPushButton("Continue without changing workspace")
+        skip.setObjectName("WelcomeSkip")
+        skip.setCursor(Qt.CursorShape.PointingHandCursor)
+        skip.setAutoDefault(False)
+        skip.clicked.connect(self._on_skip)
+        lay.addWidget(skip, 0, Qt.AlignmentFlag.AlignHCenter)
+
+    def keyPressEvent(self, event: QKeyEvent) -> None:
+        if event.key() == Qt.Key.Key_Escape:
+            self._on_skip()
+            event.accept()
+            return
+        super().keyPressEvent(event)
+
+    @property
+    def choice(self) -> WelcomeChoice:
+        return self._choice
+
+    def _on_open(self) -> None:
+        self._choice = "open"
+        self.accept()
+
+    def _on_new(self) -> None:
+        self._choice = "new"
+        self.accept()
+
+    def _on_skip(self) -> None:
+        self._choice = "skip"
+        self.accept()


### PR DESCRIPTION
## Summary
- patch NodeGraphQt/PySide compatibility and run Qt plugin bootstrap before app UI setup
- refresh the UI with a cleaner VS Code-inspired theme and clearer inspector labels/tooltips
- add welcome/new-file onboarding plus a terminal tab alongside the run log

## Test plan
- [x] `python -m pytest -q`
- [x] `python -m ml_pipeline_studio`
- [x] verify inspector loads numeric fields without `NoButtons` crash
- [x] verify Welcome -> New opens tutorial flow
- [x] verify bottom dock includes both Run log and Terminal tabs