### PR TITLE
feat(ui): add VS Code-style header navigation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,8 @@ requires-python = ">=3.9"
 license = { text = "MIT" }
 authors = [{ name = "ML Pipeline Studio" }]
 dependencies = [
-    "NodeGraphQt>=0.6.44",
-    "PySide6>=6.6.0",
+    "NodeGraphQt>=0.6.44,<0.7",
+    "PySide6>=6.6,<6.8",
     "pydantic>=2.5",
     "numpy>=1.24",
     "pandas>=2.0",

--- a/src/ml_pipeline_studio/app.py
+++ b/src/ml_pipeline_studio/app.py
@@ -4,21 +4,44 @@ from __future__ import annotations
 
 import sys
 
-from ml_pipeline_studio.nodegraphqt_compat import apply_nodegraphqt_compat
-from ml_pipeline_studio.qt_plugin_bootstrap import apply_qt_plugin_environment
+from PySide6.QtCore import Signal
+from PySide6.QtWidgets import QAbstractSpinBox, QApplication
 
-apply_qt_plugin_environment()
-apply_nodegraphqt_compat()
+from ml_pipeline_studio.ui.main_window import MainWindow
+from ml_pipeline_studio.ui.theme import apply_theme
+
+
+def _patch_nodegraphqt_spinboxes() -> None:
+    """Patch NodeGraphQt property widgets for PySide enum compatibility."""
+    try:
+        from NodeGraphQt.custom_widgets.properties_bin import prop_widgets_base as pwb
+    except Exception:
+        return
+
+    def _spin_init(self, parent=None):  # type: ignore[no-untyped-def]
+        pwb.QtWidgets.QSpinBox.__init__(self, parent)
+        self._name = None
+        self.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
+        self.valueChanged.connect(self._on_value_change)
+
+    def _double_spin_init(self, parent=None):  # type: ignore[no-untyped-def]
+        pwb.QtWidgets.QDoubleSpinBox.__init__(self, parent)
+        self._name = None
+        self.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
+        self.valueChanged.connect(self._on_value_change)
+
+    # Rebind with the exact signal shape used by NodeGraphQt.
+    pwb.PropSpinBox.value_changed = Signal(str, object)
+    pwb.PropDoubleSpinBox.value_changed = Signal(str, object)
+    pwb.PropSpinBox.__init__ = _spin_init
+    pwb.PropDoubleSpinBox.__init__ = _double_spin_init
+
 
 def main() -> None:
-    from PySide6.QtWidgets import QApplication
-
-    from ml_pipeline_studio.ui.main_window import MainWindow
-    from ml_pipeline_studio.ui.theme import configure_application_font
-
+    _patch_nodegraphqt_spinboxes()
     app = QApplication(sys.argv)
     app.setApplicationName("ML Pipeline Studio")
-    configure_application_font(app)
+    apply_theme(app)
     win = MainWindow()
     win.show()
     sys.exit(app.exec())

--- a/src/ml_pipeline_studio/ui/header_nav.py
+++ b/src/ml_pipeline_studio/ui/header_nav.py
@@ -1,0 +1,130 @@
+"""VS Code–style header navigation bar.
+
+The header is a thin custom widget that replaces the native menu bar with a
+flat, modern toolbar containing:
+
+    [logo + title]  File  Template  Add Node  Run  Settings   <file pill>   Save  Run▶
+
+Menus are exposed as ``QMenu`` instances created here and populated by
+``MainWindow``. Quick actions (Save, Run) emit Qt signals so the main window
+can wire them to the same handlers used by keyboard shortcuts.
+"""
+
+from __future__ import annotations
+
+from PySide6.QtCore import Qt, Signal
+from PySide6.QtGui import QFont
+from PySide6.QtWidgets import (
+    QHBoxLayout,
+    QLabel,
+    QMenu,
+    QSizePolicy,
+    QToolButton,
+    QWidget,
+)
+
+
+class HeaderNavBar(QWidget):
+    """Top-of-window navigation bar with menu buttons and quick actions."""
+
+    save_clicked = Signal()
+    run_clicked = Signal()
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setObjectName("HeaderNav")
+        self.setFixedHeight(40)
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+
+        self._menus: dict[str, QMenu] = {}
+        self._menu_buttons: dict[str, QToolButton] = {}
+        self._file_label: QLabel
+        self._run_button: QToolButton
+
+        self._build()
+
+    # ------------------------------------------------------------------ build
+
+    def _build(self) -> None:
+        root = QHBoxLayout(self)
+        root.setContentsMargins(0, 0, 8, 0)
+        root.setSpacing(2)
+
+        logo = QLabel("◆")
+        logo.setObjectName("HeaderLogo")
+        logo.setToolTip("ML Pipeline Studio")
+        root.addWidget(logo)
+
+        title = QLabel("ML Pipeline Studio")
+        title.setObjectName("HeaderTitle")
+        root.addWidget(title)
+
+        root.addSpacing(12)
+
+        for label in ("File", "Template", "Add Node", "Run", "Settings"):
+            btn = self._make_menu_button(label)
+            root.addWidget(btn)
+
+        root.addSpacing(16)
+        root.addStretch(1)
+
+        self._file_label = QLabel("Untitled pipeline")
+        self._file_label.setObjectName("HeaderFile")
+        self._file_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self._file_label.setToolTip("Current pipeline file")
+        root.addWidget(self._file_label, 0, Qt.AlignmentFlag.AlignCenter)
+
+        root.addStretch(1)
+
+        save_btn = QToolButton()
+        save_btn.setObjectName("HeaderActionButton")
+        save_btn.setText("Save")
+        save_btn.setToolTip("Save pipeline (⌘S)")
+        save_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        save_btn.clicked.connect(self.save_clicked.emit)
+        root.addWidget(save_btn)
+
+        run_btn = QToolButton()
+        run_btn.setObjectName("HeaderRunButton")
+        run_btn.setText("▶  Run")
+        run_btn.setToolTip("Run pipeline (⌘R)")
+        run_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        run_btn.setFont(QFont("", 12, QFont.Weight.DemiBold))
+        run_btn.clicked.connect(self.run_clicked.emit)
+        self._run_button = run_btn
+        root.addWidget(run_btn)
+
+    def _make_menu_button(self, label: str) -> QToolButton:
+        btn = QToolButton(self)
+        btn.setObjectName("HeaderMenuButton")
+        btn.setText(label)
+        btn.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
+        btn.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextOnly)
+        btn.setAutoRaise(True)
+        btn.setCursor(Qt.CursorShape.PointingHandCursor)
+
+        menu = QMenu(btn)
+        btn.setMenu(menu)
+
+        self._menus[label] = menu
+        self._menu_buttons[label] = btn
+        return btn
+
+    # -------------------------------------------------------------- public API
+
+    def menu(self, name: str) -> QMenu:
+        """Return the menu attached to a header menu button."""
+        return self._menus[name]
+
+    def set_file_label(self, text: str) -> None:
+        """Update the centered file-name pill."""
+        self._file_label.setText(text or "Untitled pipeline")
+
+    def set_running(self, running: bool) -> None:
+        """Toggle the Run button between idle and running states."""
+        if running:
+            self._run_button.setText("●  Running…")
+            self._run_button.setEnabled(False)
+        else:
+            self._run_button.setText("▶  Run")
+            self._run_button.setEnabled(True)

--- a/src/ml_pipeline_studio/ui/main_window.py
+++ b/src/ml_pipeline_studio/ui/main_window.py
@@ -5,19 +5,15 @@ from __future__ import annotations
 from pathlib import Path
 
 from NodeGraphQt import NodeGraph, PropertiesBinWidget
-from PySide6.QtCore import QObject, Qt, QThread, QTimer, Signal, Slot
-from PySide6.QtGui import QAction, QKeySequence, QShowEvent
+from PySide6.QtCore import QObject, Qt, QThread, Signal, Slot
+from PySide6.QtGui import QAction, QKeySequence
 from PySide6.QtWidgets import (
     QDockWidget,
     QFileDialog,
-    QFrame,
     QInputDialog,
     QMainWindow,
     QMessageBox,
-    QTabWidget,
     QTextEdit,
-    QVBoxLayout,
-    QWidget,
 )
 
 from ml_pipeline_studio.execution.engine import run_pipeline
@@ -30,10 +26,7 @@ from ml_pipeline_studio.ui.graph_bridge import (
     register_studio_nodes,
 )
 from ml_pipeline_studio.ui.graph_nodes import KIND_TO_NODE_TYPE
-from ml_pipeline_studio.ui.terminal_panel import TerminalPanel
-from ml_pipeline_studio.ui.theme import GlassPanelHost, apply_studio_chrome, connect_chrome_refresh
-from ml_pipeline_studio.ui.tutorial_dialog import TutorialDialog
-from ml_pipeline_studio.ui.welcome_dialog import WelcomeDialog
+from ml_pipeline_studio.ui.header_nav import HeaderNavBar
 
 
 def _pytorch_image_template() -> PipelineDocument:
@@ -156,118 +149,88 @@ class _RunWorker(QObject):
 class MainWindow(QMainWindow):
     def __init__(self) -> None:
         super().__init__()
-        self.setObjectName("StudioShell")
         self.setWindowTitle("ML Pipeline Studio")
-        self.resize(1280, 820)
+        self.resize(1200, 800)
 
         self._graph = NodeGraph()
         register_studio_nodes(self._graph)
         self._settings = GlobalSettings()
         self._current_path: Path | None = None
 
-        graph_widget = self._graph.widget
-        canvas_host = QWidget()
-        canvas_host.setObjectName("CanvasHost")
-        canvas_layout = QVBoxLayout(canvas_host)
-        canvas_layout.setContentsMargins(10, 10, 10, 10)
-        canvas_layout.addWidget(graph_widget)
-        self.setCentralWidget(canvas_host)
+        self._header = HeaderNavBar(self)
+        self._header.save_clicked.connect(self._save)
+        self._header.run_clicked.connect(self._run_pipeline)
+        self.setMenuWidget(self._header)
+
+        self.setCentralWidget(self._graph.widget)
 
         self._props = PropertiesBinWidget(node_graph=self._graph)
         dock_p = QDockWidget("Inspector", self)
-        dock_p.setAllowedAreas(Qt.DockWidgetArea.AllDockWidgetAreas)
-        dock_p.setFeatures(
-            QDockWidget.DockWidgetFeature.DockWidgetMovable | QDockWidget.DockWidgetFeature.DockWidgetFloatable
-        )
-        dock_p.setWidget(GlassPanelHost(self._props, dock_p))
+        dock_p.setWidget(self._props)
         self.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, dock_p)
 
         self._log = QTextEdit()
-        self._log.setObjectName("StudioLog")
         self._log.setReadOnly(True)
-        self._log.setFrameShape(QFrame.Shape.NoFrame)
-        self._terminal = TerminalPanel()
-        log_tabs = QTabWidget()
-        log_tabs.addTab(self._log, "Run log")
-        log_tabs.addTab(self._terminal, "Terminal")
-
         dock_l = QDockWidget("Run log", self)
-        dock_l.setAllowedAreas(Qt.DockWidgetArea.BottomDockWidgetArea | Qt.DockWidgetArea.TopDockWidgetArea)
-        dock_l.setFeatures(
-            QDockWidget.DockWidgetFeature.DockWidgetMovable | QDockWidget.DockWidgetFeature.DockWidgetFloatable
-        )
-        dock_l.setWidget(GlassPanelHost(log_tabs, dock_l))
+        dock_l.setWidget(self._log)
         self.addDockWidget(Qt.DockWidgetArea.BottomDockWidgetArea, dock_l)
+
+        self.statusBar().showMessage("Ready")
 
         self._build_menu()
 
-        apply_studio_chrome(self)
-        connect_chrome_refresh(self)
-
         self._thread: QThread | None = None
         self._worker: _RunWorker | None = None
-        self._welcome_shown = False
-
-    def showEvent(self, event: QShowEvent) -> None:
-        super().showEvent(event)
-        if not self._welcome_shown:
-            self._welcome_shown = True
-            QTimer.singleShot(0, self._show_welcome_dialog)
-
-    def _show_welcome_dialog(self) -> None:
-        dlg = WelcomeDialog(self)
-        dlg.exec()
-        if dlg.choice == "open":
-            self._open()
-        elif dlg.choice == "new":
-            self._new()
-            TutorialDialog(self).exec()
 
     def _build_menu(self) -> None:
-        mb = self.menuBar()
-        file_m = mb.addMenu("&File")
-        act_new = QAction("&New", self)
+        file_m = self._header.menu("File")
+        act_new = QAction("New", self)
         act_new.setShortcut(QKeySequence.StandardKey.New)
         act_new.triggered.connect(self._new)
         file_m.addAction(act_new)
-        act_open = QAction("&Open…", self)
+        act_open = QAction("Open…", self)
         act_open.setShortcut(QKeySequence.StandardKey.Open)
         act_open.triggered.connect(self._open)
         file_m.addAction(act_open)
-        act_save = QAction("&Save", self)
+        act_save = QAction("Save", self)
         act_save.setShortcut(QKeySequence.StandardKey.Save)
         act_save.triggered.connect(self._save)
         file_m.addAction(act_save)
-        act_save_as = QAction("Save &As…", self)
+        act_save_as = QAction("Save As…", self)
+        act_save_as.setShortcut(QKeySequence.StandardKey.SaveAs)
         act_save_as.triggered.connect(self._save_as)
         file_m.addAction(act_save_as)
         file_m.addSeparator()
-        act_quit = QAction("&Quit", self)
+        act_quit = QAction("Quit", self)
         act_quit.setShortcut(QKeySequence.StandardKey.Quit)
         act_quit.triggered.connect(self.close)
         file_m.addAction(act_quit)
 
-        tpl_m = mb.addMenu("&Template")
+        tpl_m = self._header.menu("Template")
         act_tpl = QAction("PyTorch image classification…", self)
         act_tpl.triggered.connect(self._template_pt_image)
         tpl_m.addAction(act_tpl)
 
-        add_m = mb.addMenu("&Add node")
+        add_m = self._header.menu("Add Node")
         for kind, ntype in sorted(KIND_TO_NODE_TYPE.items(), key=lambda x: x[0]):
             act = QAction(kind.replace("_", " ").title(), self)
             act.triggered.connect(lambda checked=False, t=ntype: self._add_node(t))
             add_m.addAction(act)
 
-        run_m = mb.addMenu("&Run")
-        act_run = QAction("&Run pipeline", self)
+        run_m = self._header.menu("Run")
+        act_run = QAction("Run pipeline", self)
         act_run.setShortcut("Ctrl+R")
         act_run.triggered.connect(self._run_pipeline)
         run_m.addAction(act_run)
 
-        set_m = mb.addMenu("&Settings")
-        act_set = QAction("Run &settings…", self)
+        set_m = self._header.menu("Settings")
+        act_set = QAction("Run settings…", self)
         act_set.triggered.connect(self._edit_settings)
         set_m.addAction(act_set)
+
+        # Make shortcuts work even though the menu bar is hidden.
+        for action in (act_new, act_open, act_save, act_save_as, act_quit, act_run):
+            self.addAction(action)
 
     def _add_node(self, ntype: str) -> None:
         self._graph.create_node(ntype)
@@ -277,6 +240,7 @@ class MainWindow(QMainWindow):
         self._settings = GlobalSettings()
         self._current_path = None
         self.setWindowTitle("ML Pipeline Studio — Untitled")
+        self._header.set_file_label("Untitled pipeline")
         self._log.clear()
 
     def _open(self) -> None:
@@ -289,6 +253,7 @@ class MainWindow(QMainWindow):
             apply_document_to_graph(self._graph, doc)
             self._current_path = Path(path)
             self.setWindowTitle(f"ML Pipeline Studio — {self._current_path.name}")
+            self._header.set_file_label(self._current_path.name)
         except Exception as e:
             QMessageBox.critical(self, "Open failed", str(e))
 
@@ -308,6 +273,7 @@ class MainWindow(QMainWindow):
         self._save_to(p)
         self._current_path = p
         self.setWindowTitle(f"ML Pipeline Studio — {p.name}")
+        self._header.set_file_label(p.name)
 
     def _save_to(self, path: Path) -> None:
         doc = document_from_graph(self._graph, self._settings)
@@ -319,6 +285,7 @@ class MainWindow(QMainWindow):
         apply_document_to_graph(self._graph, doc)
         self._current_path = None
         self.setWindowTitle("ML Pipeline Studio — Template (unsaved)")
+        self._header.set_file_label("Template (unsaved)")
         QMessageBox.information(
             self,
             "Template loaded",
@@ -371,6 +338,8 @@ class MainWindow(QMainWindow):
 
         self._log.clear()
         self._append_log("Starting pipeline run…")
+        self._header.set_running(True)
+        self.statusBar().showMessage("Running pipeline…")
 
         self._thread = QThread()
         self._worker = _RunWorker(doc)
@@ -386,10 +355,14 @@ class MainWindow(QMainWindow):
 
     def _on_run_finished(self) -> None:
         self._append_log("Finished successfully.")
+        self._header.set_running(False)
+        self.statusBar().showMessage("Pipeline finished successfully", 5000)
         QMessageBox.information(self, "Run complete", "Pipeline finished successfully.")
 
     def _on_run_failed(self, msg: str) -> None:
         self._append_log(f"ERROR: {msg}")
+        self._header.set_running(False)
+        self.statusBar().showMessage("Pipeline failed", 5000)
         QMessageBox.critical(self, "Run failed", msg)
 
     def _cleanup_thread(self) -> None:

--- a/src/ml_pipeline_studio/ui/theme.py
+++ b/src/ml_pipeline_studio/ui/theme.py
@@ -1,461 +1,242 @@
-"""Liquid-glass inspired chrome: frosted panels, system-aware light/dark tokens."""
+"""Modern dark theme inspired by VS Code.
+
+Provides a single ``apply_theme(app)`` entrypoint that installs a Fusion
+palette and a stylesheet which gives the app a clean, flat look with rounded
+controls, a dim chrome and an accent color matching VS Code's blue.
+"""
 
 from __future__ import annotations
 
-import sys
+from PySide6.QtGui import QColor, QPalette
+from PySide6.QtWidgets import QApplication
 
-from PySide6.QtCore import Qt
-from PySide6.QtGui import QGuiApplication, QPalette
-from PySide6.QtWidgets import QApplication, QFrame, QMainWindow, QVBoxLayout, QWidget
+# Palette inspired by VS Code's "Dark Modern" theme.
+COLORS = {
+    "bg": "#1e1e1e",            # editor background
+    "chrome": "#252526",         # panels / sidebar
+    "chrome_alt": "#2d2d2d",     # alt panel surface
+    "header": "#3c3c3c",         # title bar / header background
+    "header_hi": "#505050",      # header hover
+    "border": "#3c3c3c",
+    "border_strong": "#454545",
+    "text": "#cccccc",
+    "text_dim": "#9d9d9d",
+    "text_strong": "#ffffff",
+    "accent": "#0e639c",         # VS Code "command" blue
+    "accent_hi": "#1177bb",
+    "danger": "#a1260d",
+    "ok": "#16825d",
+}
 
 
-def _is_dark_color_scheme() -> bool:
-    hints = QGuiApplication.styleHints()
-    scheme = hints.colorScheme()
-    if scheme == Qt.ColorScheme.Dark:
-        return True
-    if scheme == Qt.ColorScheme.Light:
-        return False
-    win = QGuiApplication.palette().color(QPalette.ColorRole.Window)
-    return win.lightness() < 128
+def apply_theme(app: QApplication) -> None:
+    """Apply a dark Fusion palette and modern stylesheet."""
+    app.setStyle("Fusion")
+
+    palette = QPalette()
+    palette.setColor(QPalette.ColorRole.Window, QColor(COLORS["chrome"]))
+    palette.setColor(QPalette.ColorRole.WindowText, QColor(COLORS["text"]))
+    palette.setColor(QPalette.ColorRole.Base, QColor(COLORS["bg"]))
+    palette.setColor(QPalette.ColorRole.AlternateBase, QColor(COLORS["chrome_alt"]))
+    palette.setColor(QPalette.ColorRole.Text, QColor(COLORS["text"]))
+    palette.setColor(QPalette.ColorRole.PlaceholderText, QColor(COLORS["text_dim"]))
+    palette.setColor(QPalette.ColorRole.Button, QColor(COLORS["chrome"]))
+    palette.setColor(QPalette.ColorRole.ButtonText, QColor(COLORS["text"]))
+    palette.setColor(QPalette.ColorRole.BrightText, QColor(COLORS["text_strong"]))
+    palette.setColor(QPalette.ColorRole.Highlight, QColor(COLORS["accent"]))
+    palette.setColor(QPalette.ColorRole.HighlightedText, QColor(COLORS["text_strong"]))
+    palette.setColor(QPalette.ColorRole.ToolTipBase, QColor(COLORS["chrome_alt"]))
+    palette.setColor(QPalette.ColorRole.ToolTipText, QColor(COLORS["text"]))
+    app.setPalette(palette)
+
+    app.setStyleSheet(_build_stylesheet())
 
 
-def build_studio_stylesheet(*, dark: bool) -> str:
-    """Stylesheet for QMainWindow#StudioShell in a clean VS Code-inspired look."""
-    if dark:
-        shell_a, shell_b = "#1f1f1f", "#1b1b1b"
-        canvas_a, canvas_b = "#252526", "#1e1e1e"
-        dock_title_bg = "#252526"
-        dock_title_fg = "#cccccc"
-        panel_bg = "#252526"
-        panel_border = "#3c3c3c"
-        panel_inner_border = "#2a2d2e"
-        text = "#d4d4d4"
-        muted = "#9da0a3"
-        log_bg = "#1e1e1e"
-        log_fg = "#d4d4d4"
-        selection = "rgba(38, 79, 120, 0.65)"
-        inner_surface = "#1e1e1e"
-        grid = "#313131"
-        header_bg = "#252526"
-        btn_bg = "#2d2d30"
-        btn_border = "#3f3f46"
-        btn_hover = "#37373d"
-        field_bg = "#3c3c3c"
-        field_border = "#55585c"
-        focus_border = "#007acc"
-        tab_bg = "#2d2d30"
-        tab_sel = "#1e1e1e"
-    else:
-        shell_a, shell_b = "#f3f3f3", "#ececec"
-        canvas_a, canvas_b = "#ffffff", "#f3f3f3"
-        dock_title_bg = "#f3f3f3"
-        dock_title_fg = "#2d2d2d"
-        panel_bg = "#f3f3f3"
-        panel_border = "#d0d0d0"
-        panel_inner_border = "#e3e3e3"
-        text = "#1f1f1f"
-        muted = "#5e5e5e"
-        log_bg = "#ffffff"
-        log_fg = "#1f1f1f"
-        selection = "rgba(173, 214, 255, 0.55)"
-        inner_surface = "#ffffff"
-        grid = "#e5e5e5"
-        header_bg = "#f6f6f6"
-        btn_bg = "#ececec"
-        btn_border = "#d0d0d0"
-        btn_hover = "#e2e2e2"
-        field_bg = "#ffffff"
-        field_border = "#cccccc"
-        focus_border = "#006fc9"
-        tab_bg = "#ececec"
-        tab_sel = "#ffffff"
-
+def _build_stylesheet() -> str:
+    c = COLORS
     return f"""
-QMainWindow#StudioShell {{
-  background-color: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 {shell_a}, stop:1 {shell_b});
-}}
-
-QWidget#CanvasHost {{
-  background-color: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 {canvas_a}, stop:1 {canvas_b});
-}}
-
-QDockWidget {{
-  background: transparent;
-  border: none;
-}}
-
-QDockWidget::title {{
-  text-align: left;
-  background-color: {dock_title_bg};
-  color: {dock_title_fg};
-  padding: 8px 12px;
-  border-top-left-radius: 8px;
-  border-top-right-radius: 8px;
-  font-weight: 600;
-  font-size: 12px;
-  border: 1px solid {panel_border};
-  border-bottom: none;
-}}
-
-QFrame#GlassPanelHost {{
-  background-color: {panel_bg};
-  border: 1px solid {panel_border};
-  border-radius: 8px;
-}}
-
-QTextEdit#StudioLog,
-QTextEdit#StudioTerminalOutput {{
-  background-color: {log_bg};
-  color: {log_fg};
-  border: 1px solid {panel_inner_border};
-  border-radius: 6px;
-  padding: 10px 12px;
-  font-family: "Menlo", "Monaco", "Consolas", "Courier New", monospace;
-  font-size: 12px;
-  selection-background-color: {selection};
-}}
-
-QFrame#GlassPanelHost QLabel {{
-  color: {text};
-  font-size: 12px;
-  font-weight: 500;
-}}
-
-QFrame#GlassPanelHost QTabWidget,
-QFrame#GlassPanelHost QWidget {{
-  color: {text};
-}}
-
-QFrame#GlassPanelHost QLineEdit,
-QFrame#GlassPanelHost QSpinBox,
-QFrame#GlassPanelHost QDoubleSpinBox,
-QFrame#GlassPanelHost QComboBox {{
-  background-color: {field_bg};
-  color: {text};
-  border: 1px solid {field_border};
-  border-radius: 4px;
-  padding: 5px 8px;
-  min-height: 18px;
-}}
-
-QFrame#GlassPanelHost QLineEdit:focus,
-QFrame#GlassPanelHost QSpinBox:focus,
-QFrame#GlassPanelHost QDoubleSpinBox:focus,
-QFrame#GlassPanelHost QComboBox:focus {{
-  border: 1px solid {focus_border};
-}}
-
-QFrame#GlassPanelHost QComboBox::drop-down {{
-  border: none;
-  width: 22px;
-}}
-
-QFrame#GlassPanelHost QTableWidget {{
-  background-color: {inner_surface};
-  alternate-background-color: {inner_surface};
-  color: {text};
-  gridline-color: {grid};
-  border: 1px solid {panel_inner_border};
-  border-radius: 6px;
-}}
-
-QFrame#GlassPanelHost QTableWidget::item {{
-  padding: 6px;
-}}
-
-QFrame#GlassPanelHost QTableWidget::item:selected {{
-  background-color: {selection};
-}}
-
-QFrame#GlassPanelHost QHeaderView::section {{
-  background-color: {header_bg};
-  color: {text};
-  padding: 8px;
-  border: none;
-  border-bottom: 1px solid {grid};
-  font-weight: 600;
-}}
-
-QFrame#GlassPanelHost QPushButton {{
-  background-color: {btn_bg};
-  color: {text};
-  border: 1px solid {btn_border};
-  border-radius: 4px;
-  padding: 6px 12px;
-  font-weight: 500;
-}}
-
-QFrame#GlassPanelHost QPushButton:hover {{
-  background-color: {btn_hover};
-}}
-
-QFrame#GlassPanelHost QTabWidget::pane {{
-  border: 1px solid {panel_inner_border};
-  border-radius: 6px;
-  background: {inner_surface};
-  top: 0;
-}}
-
-QFrame#GlassPanelHost QTabBar::tab {{
-  background: {tab_bg};
-  color: {muted};
-  padding: 6px 12px;
-  margin-right: 2px;
-  border-top-left-radius: 4px;
-  border-top-right-radius: 4px;
-  border: 1px solid {panel_inner_border};
-  border-bottom: none;
-}}
-
-QFrame#GlassPanelHost QTabBar::tab:selected {{
-  background: {tab_sel};
-  color: {text};
-  font-weight: 600;
-}}
-
-QFrame#GlassPanelHost QScrollBar:vertical {{
-  width: 11px;
-  background: transparent;
-  margin: 4px 2px 4px 0;
-  border-radius: 5px;
-}}
-
-QFrame#GlassPanelHost QScrollBar::handle:vertical {{
-  background: {btn_border};
-  border-radius: 5px;
-  min-height: 36px;
-}}
-
-QFrame#GlassPanelHost QScrollBar::add-line:vertical,
-QFrame#GlassPanelHost QScrollBar::sub-line:vertical {{
-  height: 0;
-}}
-
-QFrame#GlassPanelHost QScrollBar:horizontal {{
-  height: 11px;
-  background: transparent;
-  margin: 0 4px 2px 4px;
-}}
-
-QFrame#GlassPanelHost QScrollBar::handle:horizontal {{
-  background: {btn_border};
-  border-radius: 5px;
-  min-width: 36px;
-}}
-
-QFrame#GlassPanelHost QScrollBar::add-line:horizontal,
-QFrame#GlassPanelHost QScrollBar::sub-line:horizontal {{
-  width: 0;
-}}
-
-QFrame#GlassPanelHost QTreeWidget {{
-  background-color: {inner_surface};
-  color: {text};
-  border: 1px solid {panel_inner_border};
-  border-radius: 6px;
-}}
-
-QFrame#GlassPanelHost QGroupBox {{
-  border: 1px solid {panel_inner_border};
-  border-radius: 6px;
-  margin-top: 12px;
-  padding-top: 10px;
-  background: {inner_surface};
-}}
-
-QFrame#GlassPanelHost QGroupBox::title {{
-  subcontrol-origin: margin;
-  left: 10px;
-  padding: 0 4px;
-  color: {muted};
-  font-weight: 600;
-  font-size: 11px;
-}}
-
-QMenuBar {{
-  background: {shell_a};
-  color: {text};
-  border-bottom: 1px solid {panel_border};
-}}
-
-QMenuBar::item {{
-  padding: 6px 10px;
-  background: transparent;
-}}
-
-QMenuBar::item:selected {{
-  background: {btn_bg};
-  border-radius: 4px;
-}}
-
-QMenu {{
-  background: {panel_bg};
-  color: {text};
-  border: 1px solid {panel_border};
-}}
-
-QMenu::item:selected {{
-  background: {selection};
-}}
-"""
-
-
-def build_welcome_dialog_stylesheet(*, dark: bool) -> str:
-    """Styles for QDialog#WelcomeDialog — matches studio glass tokens."""
-    if dark:
-        shell_a, shell_b = "#14161c", "#0a0b0e"
-        text = "#e8eaef"
-        muted = "#9aa3b2"
-        glass_bg = "rgba(38, 42, 54, 0.88)"
-        glass_border = "rgba(255, 255, 255, 0.14)"
-        card_rest = "rgba(255, 255, 255, 0.06)"
-        card_hover = "rgba(99, 139, 255, 0.18)"
-        card_border_rest = "rgba(255, 255, 255, 0.12)"
-        card_border_hover = "rgba(118, 160, 255, 0.55)"
-        accent = "#93b4ff"
-        skip_fg = "#8b95a8"
-        skip_hover_fg = "#c8ced9"
-    else:
-        shell_a, shell_b = "#e8ecf8", "#d8dfea"
-        text = "#1c1f28"
-        muted = "#5c6578"
-        glass_bg = "rgba(255, 255, 255, 0.78)"
-        glass_border = "rgba(255, 255, 255, 0.9)"
-        card_rest = "rgba(255, 255, 255, 0.72)"
-        card_hover = "rgba(64, 120, 255, 0.12)"
-        card_border_rest = "rgba(0, 0, 0, 0.08)"
-        card_border_hover = "rgba(64, 120, 255, 0.45)"
-        accent = "#2d62f0"
-        skip_fg = "#6b7486"
-        skip_hover_fg = "#2a3140"
-
-    return f"""
-QDialog#WelcomeDialog {{
-  background-color: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 {shell_a}, stop:1 {shell_b});
-}}
-
-QFrame#WelcomePanel {{
-  background-color: {glass_bg};
-  border: 1px solid {glass_border};
-  border-radius: 24px;
-}}
-
-QLabel#WelcomeTitle {{
-  color: {text};
-  font-size: 22px;
-  font-weight: 700;
-  letter-spacing: -0.3px;
-}}
-
-QLabel#WelcomeSubtitle {{
-  color: {muted};
-  font-size: 14px;
-  font-weight: 400;
-}}
-
-QFrame#WelcomeCard {{
-  background-color: {card_rest};
-  border: 1px solid {card_border_rest};
-  border-radius: 16px;
-}}
-
-QFrame#WelcomeCard:hover {{
-  background-color: {card_hover};
-  border-color: {card_border_hover};
-}}
-
-QFrame#WelcomeCard:focus {{
-  border-color: {card_border_hover};
-}}
-
-QLabel#WelcomeCardHint {{
-  color: {muted};
-  font-size: 13px;
-  font-weight: 400;
-}}
-
-QLabel#WelcomeAccent {{
-  color: {accent};
-  font-size: 12px;
-  font-weight: 600;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-}}
-
-QLabel#WelcomeCardHeading {{
-  color: {text};
-  font-size: 16px;
-  font-weight: 700;
-}}
-
-QPushButton#WelcomeSkip {{
-  background: transparent;
-  border: none;
-  color: {skip_fg};
-  font-size: 13px;
-  font-weight: 500;
-  padding: 10px;
-}}
-
-QPushButton#WelcomeSkip:hover {{
-  color: {skip_hover_fg};
-}}
-
-QPushButton#WelcomeSkip:pressed {{
-  color: {text};
-}}
-"""
-
-
-class GlassPanelHost(QFrame):
-    """Rounded frosted container for dock content (inspector, log)."""
-
-    def __init__(self, inner: QWidget, parent: QWidget | None = None) -> None:
-        super().__init__(parent)
-        self.setObjectName("GlassPanelHost")
-        lay = QVBoxLayout(self)
-        lay.setContentsMargins(14, 14, 14, 14)
-        lay.setSpacing(0)
-        lay.addWidget(inner, 1)
-
-
-def configure_application_font(app: QApplication) -> None:
-    from PySide6.QtGui import QFont
-
-    if sys.platform == "darwin":
-        font = QFont(".AppleSystemUIFont", 13)
-    else:
-        font = QFont()
-        font.setPointSize(10)
-    app.setFont(font)
-
-
-def apply_studio_chrome(window: QMainWindow) -> None:
-    """Apply or refresh glass chrome for the main window (call after widgets exist)."""
-    dark = _is_dark_color_scheme()
-    window.setStyleSheet(build_studio_stylesheet(dark=dark))
-
-
-def connect_chrome_refresh(window: QMainWindow) -> None:
-    hints = QGuiApplication.styleHints()
-
-    def _refresh(_scheme: Qt.ColorScheme | None = None) -> None:
-        apply_studio_chrome(window)
-
-    hints.colorSchemeChanged.connect(_refresh)
-
-
-def apply_welcome_dialog_chrome(dialog: QWidget) -> None:
-    """Apply or refresh welcome dialog styles (system light/dark)."""
-    dark = _is_dark_color_scheme()
-    dialog.setStyleSheet(build_welcome_dialog_stylesheet(dark=dark))
-
-
-def connect_welcome_dialog_chrome(dialog: QWidget) -> None:
-    hints = QGuiApplication.styleHints()
-
-    def _refresh(_scheme: Qt.ColorScheme | None = None) -> None:
-        apply_welcome_dialog_chrome(dialog)
-
-    hints.colorSchemeChanged.connect(_refresh)
+    /* Base */
+    QMainWindow, QWidget {{
+        background-color: {c["chrome"]};
+        color: {c["text"]};
+        font-family: "Helvetica Neue", Arial, sans-serif;
+        font-size: 13px;
+    }}
+    * {{
+        font-family: "Helvetica Neue", Arial, sans-serif;
+    }}
+
+    QToolTip {{
+        background-color: {c["chrome_alt"]};
+        color: {c["text"]};
+        border: 1px solid {c["border_strong"]};
+        padding: 4px 6px;
+    }}
+
+    /* Header navigation bar */
+    QWidget#HeaderNav {{
+        background-color: {c["header"]};
+        border-bottom: 1px solid #1a1a1a;
+    }}
+    QLabel#HeaderTitle {{
+        color: {c["text_strong"]};
+        font-weight: 600;
+        font-size: 13px;
+        padding-left: 8px;
+    }}
+    QLabel#HeaderLogo {{
+        color: {c["accent_hi"]};
+        font-size: 16px;
+        font-weight: 700;
+        padding-left: 12px;
+    }}
+    QLabel#HeaderFile {{
+        color: {c["text_dim"]};
+        background-color: {c["bg"]};
+        border: 1px solid {c["border_strong"]};
+        border-radius: 4px;
+        padding: 3px 14px;
+        min-width: 220px;
+    }}
+    QToolButton#HeaderMenuButton {{
+        color: {c["text"]};
+        background-color: transparent;
+        border: none;
+        padding: 5px 10px;
+        border-radius: 4px;
+        font-size: 12.5px;
+    }}
+    QToolButton#HeaderMenuButton:hover,
+    QToolButton#HeaderMenuButton:focus {{
+        background-color: {c["header_hi"]};
+        color: {c["text_strong"]};
+    }}
+    QToolButton#HeaderMenuButton::menu-indicator {{
+        image: none;
+        width: 0;
+    }}
+    QToolButton#HeaderActionButton {{
+        color: {c["text"]};
+        background-color: transparent;
+        border: none;
+        padding: 4px 8px;
+        border-radius: 4px;
+    }}
+    QToolButton#HeaderActionButton:hover {{
+        background-color: {c["header_hi"]};
+        color: {c["text_strong"]};
+    }}
+    QToolButton#HeaderRunButton {{
+        color: #ffffff;
+        background-color: {c["accent"]};
+        border: none;
+        padding: 4px 14px;
+        border-radius: 4px;
+        font-weight: 600;
+    }}
+    QToolButton#HeaderRunButton:hover {{
+        background-color: {c["accent_hi"]};
+    }}
+    QToolButton#HeaderRunButton:pressed {{
+        background-color: #0a4f7d;
+    }}
+    QToolButton#HeaderRunButton:disabled {{
+        background-color: #2a4a60;
+        color: #99b3c2;
+    }}
+
+    /* Menus */
+    QMenu {{
+        background-color: {c["chrome_alt"]};
+        color: {c["text"]};
+        border: 1px solid {c["border_strong"]};
+        padding: 4px 0;
+    }}
+    QMenu::item {{
+        background-color: transparent;
+        padding: 5px 22px 5px 22px;
+    }}
+    QMenu::item:selected {{
+        background-color: {c["accent"]};
+        color: {c["text_strong"]};
+    }}
+    QMenu::separator {{
+        height: 1px;
+        background: {c["border_strong"]};
+        margin: 4px 8px;
+    }}
+
+    /* Dock widgets */
+    QDockWidget {{
+        color: {c["text"]};
+        font-size: 12px;
+    }}
+    QDockWidget::title {{
+        background-color: {c["chrome_alt"]};
+        text-align: left;
+        padding: 4px 8px;
+        border-bottom: 1px solid {c["border"]};
+    }}
+    QDockWidget > QWidget {{
+        background-color: {c["chrome"]};
+    }}
+
+    /* Text editing surfaces */
+    QTextEdit, QPlainTextEdit, QLineEdit {{
+        background-color: {c["bg"]};
+        color: {c["text"]};
+        border: 1px solid {c["border_strong"]};
+        border-radius: 4px;
+        selection-background-color: {c["accent"]};
+        selection-color: {c["text_strong"]};
+    }}
+
+    /* Scrollbars */
+    QScrollBar:vertical, QScrollBar:horizontal {{
+        background: {c["chrome"]};
+        border: none;
+        width: 10px;
+        height: 10px;
+    }}
+    QScrollBar::handle:vertical, QScrollBar::handle:horizontal {{
+        background: #4a4a4a;
+        border-radius: 4px;
+        min-height: 24px;
+        min-width: 24px;
+    }}
+    QScrollBar::handle:hover {{ background: #5a5a5a; }}
+    QScrollBar::add-line, QScrollBar::sub-line {{ height: 0; width: 0; }}
+    QScrollBar::add-page, QScrollBar::sub-page {{ background: transparent; }}
+
+    /* Status bar */
+    QStatusBar {{
+        background-color: {c["accent"]};
+        color: #ffffff;
+        font-size: 12px;
+    }}
+    QStatusBar::item {{ border: none; }}
+
+    /* Inputs / buttons in dialogs */
+    QPushButton {{
+        background-color: {c["chrome_alt"]};
+        color: {c["text"]};
+        border: 1px solid {c["border_strong"]};
+        border-radius: 4px;
+        padding: 5px 14px;
+    }}
+    QPushButton:hover {{ background-color: {c["header_hi"]}; }}
+    QPushButton:default {{
+        background-color: {c["accent"]};
+        color: #ffffff;
+        border: 1px solid {c["accent"]};
+    }}
+    QPushButton:default:hover {{ background-color: {c["accent_hi"]}; }}
+
+    QComboBox, QSpinBox, QDoubleSpinBox {{
+        background-color: {c["bg"]};
+        color: {c["text"]};
+        border: 1px solid {c["border_strong"]};
+        border-radius: 4px;
+        padding: 3px 6px;
+    }}
+    """


### PR DESCRIPTION
## Summary
- replace the native menu bar with a custom VS Code-style header navigation bar
- introduce a cohesive dark theme for the header, menus, docks, and status chrome
- wire quick header actions for save/run and keep file/run state reflected in the header UI

## Test plan
- [ ] Launch the app and confirm the header bar is visible at the top
- [ ] Verify File/Template/Add Node/Run/Settings menus open and trigger expected actions
- [ ] Verify Save and Run quick actions from the header work
- [ ] Confirm inspector and run log docks render correctly under the new theme

Made with [Cursor](https://cursor.com)