### PR TITLE
Redshale UI: branding, theme, inspector, and window icon

### DIFF
--- a/Cooties.json
+++ b/Cooties.json
@@ -1,0 +1,125 @@
+{
+  "version": 1,
+  "settings": {
+    "random_seed": 42,
+    "run_output_dir": "./ml_runs",
+    "pytorch_device": "auto",
+    "tensorflow_device": "auto"
+  },
+  "nodes": [
+    {
+      "id": "dataset1",
+      "kind": "dataset",
+      "position": [
+        -400.0,
+        0.0
+      ],
+      "params": {
+        "dataset_mode": "image_folder",
+        "data_path": "",
+        "label_column": "",
+        "train_ratio": 0.7,
+        "val_ratio": 0.15,
+        "test_ratio": 0.15
+      }
+    },
+    {
+      "id": "pre1",
+      "kind": "preprocess",
+      "position": [
+        -200.0,
+        0.0
+      ],
+      "params": {
+        "preprocess_preset": "image_basic",
+        "image_size": 224
+      }
+    },
+    {
+      "id": "train1",
+      "kind": "train_pytorch",
+      "position": [
+        0.0,
+        0.0
+      ],
+      "params": {
+        "model_preset": "cnn_small",
+        "epochs": 3,
+        "batch_size": 8,
+        "learning_rate": 0.001
+      }
+    },
+    {
+      "id": "eval1",
+      "kind": "evaluate",
+      "position": [
+        200.0,
+        -80.0
+      ],
+      "params": {
+        "eval_split": "test"
+      }
+    },
+    {
+      "id": "val1",
+      "kind": "validate",
+      "position": [
+        400.0,
+        -80.0
+      ],
+      "params": {
+        "min_accuracy": 0.01
+      }
+    },
+    {
+      "id": "export1",
+      "kind": "export",
+      "position": [
+        200.0,
+        120.0
+      ],
+      "params": {
+        "export_format": "pt",
+        "export_path": ""
+      }
+    }
+  ],
+  "edges": [
+    {
+      "source_node": "dataset1",
+      "source_port": "data",
+      "target_node": "pre1",
+      "target_port": "data"
+    },
+    {
+      "source_node": "pre1",
+      "source_port": "data",
+      "target_node": "train1",
+      "target_port": "data"
+    },
+    {
+      "source_node": "pre1",
+      "source_port": "data",
+      "target_node": "eval1",
+      "target_port": "data"
+    },
+    {
+      "source_node": "train1",
+      "source_port": "model",
+      "target_node": "eval1",
+      "target_port": "model"
+    },
+    {
+      "source_node": "train1",
+      "source_port": "model",
+      "target_node": "export1",
+      "target_port": "model"
+    },
+    {
+      "source_node": "eval1",
+      "source_port": "metrics",
+      "target_node": "val1",
+      "target_port": "metrics"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Redshale ML Pipeline Studio
+# Redshale
 
 macOS-first **desktop app** for building **no-code** ML pipelines as a **node graph**: dataset → preprocess → train (PyTorch or TensorFlow) → evaluate → quality gate → export.
 
@@ -48,7 +48,7 @@ This tree is intended to be the root of a **dedicated repo** (not nested in a st
 ```bash
 git init
 git add .
-git commit -m "Initial ML Pipeline Studio scaffold"
+git commit -m "Initial Redshale scaffold"
 git remote add origin https://github.com/<you>/ml-pipeline-studio.git
 git push -u origin main
 ```
@@ -72,4 +72,3 @@ Notarization requires an Apple Developer ID; distribute unsigned builds for loca
 ## License
 
 MIT
-# Redshale

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,11 +5,11 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ml-pipeline-studio"
 version = "0.1.0"
-description = "macOS-first no-code ML pipeline builder (PySide6 + node graph, PyTorch/TensorFlow)"
+description = "Redshale — macOS-first no-code ML pipeline builder (PySide6 + node graph, PyTorch/TensorFlow)"
 readme = "README.md"
 requires-python = ">=3.9"
 license = { text = "MIT" }
-authors = [{ name = "ML Pipeline Studio" }]
+authors = [{ name = "Redshale" }]
 dependencies = [
     "NodeGraphQt>=0.6.44,<0.7",
     "PySide6>=6.6,<6.8",

--- a/src/ml_pipeline_studio/__init__.py
+++ b/src/ml_pipeline_studio/__init__.py
@@ -1,3 +1,3 @@
-"""ML Pipeline Studio — visual no-code ML pipeline desktop app."""
+"""Redshale — visual no-code ML pipeline desktop app."""
 
 __version__ = "0.1.0"

--- a/src/ml_pipeline_studio/app.py
+++ b/src/ml_pipeline_studio/app.py
@@ -4,45 +4,23 @@ from __future__ import annotations
 
 import sys
 
-from PySide6.QtCore import Signal
-from PySide6.QtWidgets import QAbstractSpinBox, QApplication
+from PySide6.QtWidgets import QApplication
 
+from ml_pipeline_studio.nodegraphqt_compat import apply_nodegraphqt_compat
+from ml_pipeline_studio.ui.app_icon import application_icon
 from ml_pipeline_studio.ui.main_window import MainWindow
 from ml_pipeline_studio.ui.theme import apply_theme
 
 
-def _patch_nodegraphqt_spinboxes() -> None:
-    """Patch NodeGraphQt property widgets for PySide enum compatibility."""
-    try:
-        from NodeGraphQt.custom_widgets.properties_bin import prop_widgets_base as pwb
-    except Exception:
-        return
-
-    def _spin_init(self, parent=None):  # type: ignore[no-untyped-def]
-        pwb.QtWidgets.QSpinBox.__init__(self, parent)
-        self._name = None
-        self.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
-        self.valueChanged.connect(self._on_value_change)
-
-    def _double_spin_init(self, parent=None):  # type: ignore[no-untyped-def]
-        pwb.QtWidgets.QDoubleSpinBox.__init__(self, parent)
-        self._name = None
-        self.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
-        self.valueChanged.connect(self._on_value_change)
-
-    # Rebind with the exact signal shape used by NodeGraphQt.
-    pwb.PropSpinBox.value_changed = Signal(str, object)
-    pwb.PropDoubleSpinBox.value_changed = Signal(str, object)
-    pwb.PropSpinBox.__init__ = _spin_init
-    pwb.PropDoubleSpinBox.__init__ = _double_spin_init
-
-
 def main() -> None:
-    _patch_nodegraphqt_spinboxes()
+    apply_nodegraphqt_compat()
     app = QApplication(sys.argv)
-    app.setApplicationName("ML Pipeline Studio")
+    app.setApplicationName("Redshale")
+    icon = application_icon()
+    app.setWindowIcon(icon)
     apply_theme(app)
     win = MainWindow()
+    win.setWindowIcon(icon)
     win.show()
     sys.exit(app.exec())
 

--- a/src/ml_pipeline_studio/nodegraphqt_compat.py
+++ b/src/ml_pipeline_studio/nodegraphqt_compat.py
@@ -1,23 +1,4 @@
-"""Compatibility shims for NodeGraphQt against newer PySide6 releases.
-
-NodeGraphQt 0.6.x ships ``PropSpinBox``/``PropDoubleSpinBox`` whose ``__init__``
-calls ``self.setButtonSymbols(self.NoButtons)``. PySide6 >= 6.7 stopped
-exposing scoped-enum members as *instance* attributes (class-level access like
-``QSpinBox.NoButtons`` still works), so the unmodified library raises::
-
-    AttributeError: 'PropDoubleSpinBox' object has no attribute 'NoButtons'
-
-the first time the Inspector dock builds an editor for a numeric property.
-
-The shim re-implements those two ``__init__`` methods to use the
-``QAbstractSpinBox.ButtonSymbols`` enum directly.
-
-We also patch property labels to be easier to scan in the inspector:
-- convert underscored labels into Title Case.
-- ensure the built-in `name` field uses `Name`.
-
-This module must run *before* any ``PropertiesBinWidget`` constructs editors.
-"""
+"""Compatibility shims for NodeGraphQt against newer PySide6 and Redshale inspector UI."""
 
 from __future__ import annotations
 
@@ -25,27 +6,29 @@ _PATCHED = False
 
 
 def apply_nodegraphqt_compat() -> None:
-    """Idempotently patch NodeGraphQt's spinbox property widgets for PySide6 >= 6.7."""
+    """Patch spinboxes, property labels, and inspector layout (call before ``PropertiesBinWidget`` exists)."""
 
     global _PATCHED
     if _PATCHED:
         return
 
     try:
+        from PySide6.QtCore import Qt, Signal
+        from PySide6.QtWidgets import (
+            QAbstractSpinBox,
+            QDoubleSpinBox,
+            QFrame,
+            QGridLayout,
+            QLabel,
+            QSpinBox,
+            QTabWidget,
+        )
+
         from NodeGraphQt.custom_widgets.properties_bin import (
             node_property_widgets as _prop_widgets,
         )
         from NodeGraphQt.custom_widgets.properties_bin import (
             prop_widgets_base as _base,
-        )
-    except ImportError:
-        return
-
-    try:
-        from PySide6.QtWidgets import (
-            QAbstractSpinBox,
-            QDoubleSpinBox,
-            QSpinBox,
         )
     except ImportError:
         return
@@ -68,18 +51,50 @@ def apply_nodegraphqt_compat() -> None:
     prop_dspin = getattr(_base, "PropDoubleSpinBox", None)
 
     if prop_spin is not None:
+        prop_spin.value_changed = Signal(str, object)
         prop_spin.__init__ = _patched_spin_init  # type: ignore[method-assign]
     if prop_dspin is not None:
+        prop_dspin.value_changed = Signal(str, object)
         prop_dspin.__init__ = _patched_dspin_init  # type: ignore[method-assign]
 
     prop_container = getattr(_prop_widgets, "_PropertiesContainer", None)
     if prop_container is not None:
-        orig_add_widget = prop_container.add_widget
 
-        def _patched_add_widget(self, name, widget, value, label=None, tooltip=None):
-            pretty = label or name
-            pretty = pretty.replace("_", " ").strip().title()
-            return orig_add_widget(self, name, widget, value, pretty, tooltip)
+        def _patched_add_widget(self, name, widget, value, label=None, tooltip=None):  # type: ignore[no-untyped-def]
+            raw_label = label if label is not None else name
+            pretty = raw_label.replace("_", " ").strip().title()
+            label_widget = QLabel(pretty)
+            label_widget.setObjectName("InspectorPropLabel")
+            if tooltip:
+                widget.setToolTip("{}\n{}".format(name, tooltip))
+                label_widget.setToolTip("{}\n{}".format(name, tooltip))
+            else:
+                widget.setToolTip(name)
+                label_widget.setToolTip(name)
+            widget.set_value(value)
+
+            grid_layout = getattr(self, "_PropertiesContainer__layout")
+            prop_widgets = getattr(self, "_PropertiesContainer__property_widgets")
+
+            row = grid_layout.rowCount()
+            if row > 0:
+                row += 1
+
+            label_flags = Qt.AlignmentFlag.AlignVCenter | Qt.AlignmentFlag.AlignRight
+            if widget.__class__.__name__ == "PropTextEdit":
+                label_flags |= Qt.AlignmentFlag.AlignTop
+
+            field = QFrame()
+            field.setObjectName("InspectorField")
+            inner = QGridLayout(field)
+            inner.setContentsMargins(10, 8, 12, 8)
+            inner.setHorizontalSpacing(14)
+            inner.setColumnStretch(1, 1)
+            inner.addWidget(label_widget, 0, 0, label_flags)
+            inner.addWidget(widget, 0, 1)
+
+            grid_layout.addWidget(field, row, 0, 1, 2)
+            prop_widgets[name] = widget
 
         prop_container.add_widget = _patched_add_widget  # type: ignore[method-assign]
 
@@ -87,12 +102,24 @@ def apply_nodegraphqt_compat() -> None:
     if node_editor is not None:
         orig_init = node_editor.__init__
 
-        def _patched_editor_init(self, node=None, parent=None):
+        def _patched_editor_init(self, node=None, parent=None):  # type: ignore[no-untyped-def]
             orig_init(self, node=node, parent=parent)
-            name_labels = self.findChildren(_prop_widgets.QtWidgets.QLabel)
+            self.setObjectName("InspectorNodeCard")
+            self.icon_label.setObjectName("InspectorNodeIcon")
+            # ``__tab`` is name-mangled on ``NodePropEditorWidget``; this patched ``__init__``
+            # lives at module scope so ``self.__tab`` does not resolve — use mangled attr
+            # or fall back to finding the tab widget.
+            tab_w = getattr(self, "_NodePropEditorWidget__tab", None)
+            if tab_w is None:
+                tab_w = self.findChild(QTabWidget)
+            if tab_w is not None:
+                tab_w.setObjectName("InspectorTabs")
+            self.type_wgt.setObjectName("InspectorNodeTypeFooter")
+            name_labels = self.findChildren(QLabel)
             for lbl in name_labels:
                 if lbl.text() == "name":
                     lbl.setText("Name")
+                    lbl.setObjectName("InspectorHeaderLabel")
                     break
 
         node_editor.__init__ = _patched_editor_init  # type: ignore[method-assign]

--- a/src/ml_pipeline_studio/nodegraphqt_compat.py
+++ b/src/ml_pipeline_studio/nodegraphqt_compat.py
@@ -13,6 +13,12 @@ def apply_nodegraphqt_compat() -> None:
         return
 
     try:
+        from NodeGraphQt.custom_widgets.properties_bin import (
+            node_property_widgets as _prop_widgets,
+        )
+        from NodeGraphQt.custom_widgets.properties_bin import (
+            prop_widgets_base as _base,
+        )
         from PySide6.QtCore import Qt, Signal
         from PySide6.QtWidgets import (
             QAbstractSpinBox,
@@ -22,13 +28,6 @@ def apply_nodegraphqt_compat() -> None:
             QLabel,
             QSpinBox,
             QTabWidget,
-        )
-
-        from NodeGraphQt.custom_widgets.properties_bin import (
-            node_property_widgets as _prop_widgets,
-        )
-        from NodeGraphQt.custom_widgets.properties_bin import (
-            prop_widgets_base as _base,
         )
     except ImportError:
         return

--- a/src/ml_pipeline_studio/ui/app_icon.py
+++ b/src/ml_pipeline_studio/ui/app_icon.py
@@ -1,0 +1,165 @@
+"""Application window icon — Redshale wordmark + accent dot on a rounded-rect macOS-style mask."""
+
+from __future__ import annotations
+
+from PySide6.QtCore import QPoint, QRectF, Qt
+from PySide6.QtGui import (
+    QColor,
+    QFont,
+    QFontMetrics,
+    QIcon,
+    QPainter,
+    QPainterPath,
+    QPixmap,
+)
+
+from ml_pipeline_studio.ui.theme import COLORS
+
+_ICON_CACHE: QIcon | None = None
+
+_ICON_BACKGROUND = QColor("#000000")
+
+# macOS app icons use a continuous-corner shape (squircle); rounded-rect with ~22.37% radius matches closely.
+_ICON_CORNER_RATIO = 0.2237
+
+
+def _rounded_icon_shape(side: int) -> QPainterPath:
+    """Rounded rectangle approximating the standard macOS app-icon silhouette."""
+    radius = max(float(side) * _ICON_CORNER_RATIO, 2.0)
+    inset = 0.25
+    w = float(side) - 2 * inset
+    path = QPainterPath()
+    path.addRoundedRect(QRectF(inset, inset, w, w), radius, radius)
+    return path
+
+
+def _baseline_center_vertically(side: int, fm: QFontMetrics) -> int:
+    """Baseline y for a single horizontally centered line of text."""
+    return (side - fm.height()) // 2 + fm.ascent()
+
+
+def _render_compact(side: int) -> QPixmap:
+    """Small dock/taskbar sizes: bold ``R`` + accent dot (readable when scaled down)."""
+    pm = QPixmap(side, side)
+    pm.fill(Qt.GlobalColor.transparent)
+
+    text_col = QColor(COLORS["text_strong"])
+    accent = QColor(COLORS["accent"])
+
+    p = QPainter(pm)
+    p.setRenderHint(QPainter.RenderHint.Antialiasing)
+    p.setRenderHint(QPainter.RenderHint.TextAntialiasing)
+
+    shape = _rounded_icon_shape(side)
+    p.fillPath(shape, _ICON_BACKGROUND)
+    p.setClipPath(shape)
+
+    letter_px = max(int(side * 0.48), 10)
+    font = QFont("Plus Jakarta Sans")
+    font.setPixelSize(letter_px)
+    font.setWeight(QFont.Weight.Bold)
+    font.setStyleHint(QFont.StyleHint.SansSerif)
+    p.setFont(font)
+    fm = QFontMetrics(font)
+
+    letter = "R"
+    lw = fm.horizontalAdvance(letter)
+    baseline = _baseline_center_vertically(side, fm)
+    gap = max(1, side // 32)
+    dot_r = max(side // 9, 3)
+    cluster_w = lw + gap + 2 * dot_r
+    x = (side - cluster_w) // 2
+    p.setPen(text_col)
+    p.drawText(QPoint(x, baseline), letter)
+
+    cx = x + lw + gap + dot_r
+    cy = baseline - max(1, dot_r // 2)
+    p.setBrush(accent)
+    p.setPen(Qt.PenStyle.NoPen)
+    p.drawEllipse(int(cx - dot_r), int(cy - dot_r), int(2 * dot_r), int(2 * dot_r))
+
+    p.end()
+    return pm
+
+
+def _render_wordmark(side: int) -> QPixmap:
+    """Larger sizes: ``Redshale`` + bullet, scaled to fit."""
+    pm = QPixmap(side, side)
+    pm.fill(Qt.GlobalColor.transparent)
+
+    text_col = QColor(COLORS["text_strong"])
+    accent = QColor(COLORS["accent"])
+
+    margin = max(side // 16, 4)
+    inner = side - 2 * margin
+
+    word_px = max(inner // 7, 11)
+    dot_px = max(inner // 11, 7)
+
+    word = "Redshale"
+    bullet = "●"
+
+    for _ in range(24):
+        word_font = QFont("Plus Jakarta Sans")
+        word_font.setPixelSize(word_px)
+        word_font.setWeight(QFont.Weight.Medium)
+        word_font.setStyleHint(QFont.StyleHint.SansSerif)
+        dot_font = QFont("Plus Jakarta Sans")
+        dot_font.setPixelSize(dot_px)
+        dot_font.setWeight(QFont.Weight.Bold)
+        dot_font.setStyleHint(QFont.StyleHint.SansSerif)
+
+        fm_w = QFontMetrics(word_font)
+        fm_d = QFontMetrics(dot_font)
+        tw = fm_w.horizontalAdvance(word)
+        dw = fm_d.horizontalAdvance(bullet)
+        total = tw + dw + max(1, inner // 64)
+
+        if total <= inner and fm_w.height() <= inner:
+            break
+        word_px = max(word_px - 1, 8)
+        dot_px = max(dot_px - 1, 5)
+
+    p = QPainter(pm)
+    p.setRenderHint(QPainter.RenderHint.Antialiasing)
+    p.setRenderHint(QPainter.RenderHint.TextAntialiasing)
+
+    shape = _rounded_icon_shape(side)
+    p.fillPath(shape, _ICON_BACKGROUND)
+    p.setClipPath(shape)
+
+    baseline = _baseline_center_vertically(side, fm_w)
+    x = (side - total) // 2
+
+    p.setFont(word_font)
+    p.setPen(text_col)
+    p.drawText(QPoint(x, baseline), word)
+
+    p.setFont(dot_font)
+    p.setPen(accent)
+    bx = x + tw + max(0, side // 256)
+    p.drawText(QPoint(bx, baseline), bullet)
+
+    p.end()
+    return pm
+
+
+def _render_pixmap(side: int) -> QPixmap:
+    if side <= 52:
+        return _render_compact(side)
+    return _render_wordmark(side)
+
+
+def application_icon() -> QIcon:
+    """Cached multi-resolution ``QIcon`` for the application."""
+    global _ICON_CACHE
+    if _ICON_CACHE is not None:
+        return _ICON_CACHE
+
+    icon = QIcon()
+    for side in (16, 20, 24, 32, 40, 48, 64, 96, 128, 192, 256, 384, 512):
+        pm = _render_pixmap(side)
+        icon.addPixmap(pm)
+
+    _ICON_CACHE = icon
+    return icon

--- a/src/ml_pipeline_studio/ui/graph_nodes.py
+++ b/src/ml_pipeline_studio/ui/graph_nodes.py
@@ -1,4 +1,4 @@
-"""NodeGraphQt node types for ML Pipeline Studio."""
+"""NodeGraphQt node types for Redshale."""
 
 from __future__ import annotations
 
@@ -8,7 +8,16 @@ from NodeGraphQt import BaseNode
 from NodeGraphQt.constants import NodePropWidgetEnum as W
 
 IDENT = "studio.ml_pipeline.nodes"
-PARAMS_TAB = "Parameters"
+
+# Inspector tabs — logical groupings (avoid reserved names "Node", "Ports").
+TAB_DATA = "Data"
+TAB_SPLITS = "Splits"
+TAB_TRANSFORM = "Transform"
+TAB_MODEL = "Model"
+TAB_TRAINING = "Training"
+TAB_EVAL = "Evaluation"
+TAB_QUALITY = "Quality gate"
+TAB_EXPORT = "Export"
 
 
 def _add_param(
@@ -18,6 +27,7 @@ def _add_param(
     *,
     widget_type: int,
     tooltip: str,
+    tab: str,
     items: list[str] | None = None,
 ) -> None:
     node.create_property(
@@ -26,7 +36,7 @@ def _add_param(
         items=items,
         widget_type=widget_type,
         widget_tooltip=tooltip,
-        tab=PARAMS_TAB,
+        tab=tab,
     )
 
 
@@ -46,6 +56,7 @@ class DatasetNode(BaseNode):
             tooltip="Data source format used by this pipeline.",
             items=["image_folder", "csv_tabular"],
             widget_type=W.QCOMBO_BOX.value,
+            tab=TAB_DATA,
         )
         _add_param(
             self,
@@ -53,6 +64,7 @@ class DatasetNode(BaseNode):
             "",
             widget_type=W.FILE_OPEN.value,
             tooltip="Folder or file path for dataset input.",
+            tab=TAB_DATA,
         )
         _add_param(
             self,
@@ -60,6 +72,7 @@ class DatasetNode(BaseNode):
             "",
             widget_type=W.QLINE_EDIT.value,
             tooltip="Column name containing class labels (CSV mode only).",
+            tab=TAB_DATA,
         )
         _add_param(
             self,
@@ -67,6 +80,7 @@ class DatasetNode(BaseNode):
             0.7,
             widget_type=W.QDOUBLESPIN_BOX.value,
             tooltip="Fraction of samples used for training.",
+            tab=TAB_SPLITS,
         )
         _add_param(
             self,
@@ -74,6 +88,7 @@ class DatasetNode(BaseNode):
             0.15,
             widget_type=W.QDOUBLESPIN_BOX.value,
             tooltip="Fraction of samples used for validation.",
+            tab=TAB_SPLITS,
         )
         _add_param(
             self,
@@ -81,6 +96,7 @@ class DatasetNode(BaseNode):
             0.15,
             widget_type=W.QDOUBLESPIN_BOX.value,
             tooltip="Fraction of samples used for final testing.",
+            tab=TAB_SPLITS,
         )
 
 
@@ -101,6 +117,7 @@ class PreprocessNode(BaseNode):
             tooltip="Preprocessing recipe to apply before training.",
             items=["image_basic", "passthrough", "tabular_standard", "tabular_standardize"],
             widget_type=W.QCOMBO_BOX.value,
+            tab=TAB_TRANSFORM,
         )
         _add_param(
             self,
@@ -108,6 +125,7 @@ class PreprocessNode(BaseNode):
             224,
             widget_type=W.QSPIN_BOX.value,
             tooltip="Target image width and height in pixels.",
+            tab=TAB_TRANSFORM,
         )
 
 
@@ -128,6 +146,7 @@ class TrainPyTorchNode(BaseNode):
             tooltip="Model architecture preset.",
             items=["cnn_small", "mlp_tabular"],
             widget_type=W.QCOMBO_BOX.value,
+            tab=TAB_MODEL,
         )
         _add_param(
             self,
@@ -135,6 +154,7 @@ class TrainPyTorchNode(BaseNode):
             3,
             widget_type=W.QSPIN_BOX.value,
             tooltip="Number of full training passes.",
+            tab=TAB_TRAINING,
         )
         _add_param(
             self,
@@ -142,6 +162,7 @@ class TrainPyTorchNode(BaseNode):
             32,
             widget_type=W.QSPIN_BOX.value,
             tooltip="Samples processed per training step.",
+            tab=TAB_TRAINING,
         )
         _add_param(
             self,
@@ -149,6 +170,7 @@ class TrainPyTorchNode(BaseNode):
             0.001,
             widget_type=W.QDOUBLESPIN_BOX.value,
             tooltip="Optimizer step size for parameter updates.",
+            tab=TAB_TRAINING,
         )
 
 
@@ -169,6 +191,7 @@ class TrainTensorFlowNode(BaseNode):
             tooltip="Model architecture preset.",
             items=["cnn_small", "mlp_tabular"],
             widget_type=W.QCOMBO_BOX.value,
+            tab=TAB_MODEL,
         )
         _add_param(
             self,
@@ -176,6 +199,7 @@ class TrainTensorFlowNode(BaseNode):
             3,
             widget_type=W.QSPIN_BOX.value,
             tooltip="Number of full training passes.",
+            tab=TAB_TRAINING,
         )
         _add_param(
             self,
@@ -183,6 +207,7 @@ class TrainTensorFlowNode(BaseNode):
             32,
             widget_type=W.QSPIN_BOX.value,
             tooltip="Samples processed per training step.",
+            tab=TAB_TRAINING,
         )
         _add_param(
             self,
@@ -190,6 +215,7 @@ class TrainTensorFlowNode(BaseNode):
             0.001,
             widget_type=W.QDOUBLESPIN_BOX.value,
             tooltip="Optimizer step size for parameter updates.",
+            tab=TAB_TRAINING,
         )
 
 
@@ -211,6 +237,7 @@ class EvaluateNode(BaseNode):
             tooltip="Dataset split used to compute metrics.",
             items=["val", "test"],
             widget_type=W.QCOMBO_BOX.value,
+            tab=TAB_EVAL,
         )
 
 
@@ -229,6 +256,7 @@ class ValidateNode(BaseNode):
             0.5,
             widget_type=W.QDOUBLESPIN_BOX.value,
             tooltip="Minimum required accuracy to pass this quality gate.",
+            tab=TAB_QUALITY,
         )
 
 
@@ -248,6 +276,7 @@ class ExportNode(BaseNode):
             tooltip="Serialization format for the trained model.",
             items=["pt", "onnx", "saved_model"],
             widget_type=W.QCOMBO_BOX.value,
+            tab=TAB_EXPORT,
         )
         _add_param(
             self,
@@ -255,6 +284,7 @@ class ExportNode(BaseNode):
             "",
             widget_type=W.QLINE_EDIT.value,
             tooltip="Output path for exported model artifacts.",
+            tab=TAB_EXPORT,
         )
 
 

--- a/src/ml_pipeline_studio/ui/header_nav.py
+++ b/src/ml_pipeline_studio/ui/header_nav.py
@@ -3,7 +3,7 @@
 The header is a thin custom widget that replaces the native menu bar with a
 flat, modern toolbar containing:
 
-    [logo + title]  File  Template  Add Node  Run  Settings   <file pill>   Save  Run▶
+    [Redshale + red dot]  File  Template  Add Node  Run  Settings   <file pill>   Save  Run▶
 
 Menus are exposed as ``QMenu`` instances created here and populated by
 ``MainWindow``. Quick actions (Save, Run) emit Qt signals so the main window
@@ -22,6 +22,8 @@ from PySide6.QtWidgets import (
     QToolButton,
     QWidget,
 )
+
+from ml_pipeline_studio.ui.redshale_brand import create_redshale_brand_widget
 
 
 class HeaderNavBar(QWidget):
@@ -50,14 +52,8 @@ class HeaderNavBar(QWidget):
         root.setContentsMargins(0, 0, 8, 0)
         root.setSpacing(2)
 
-        logo = QLabel("◆")
-        logo.setObjectName("HeaderLogo")
-        logo.setToolTip("ML Pipeline Studio")
-        root.addWidget(logo)
-
-        title = QLabel("ML Pipeline Studio")
-        title.setObjectName("HeaderTitle")
-        root.addWidget(title)
+        brand = create_redshale_brand_widget(self, variant="header")
+        root.addWidget(brand, 0, Qt.AlignmentFlag.AlignVCenter)
 
         root.addSpacing(12)
 

--- a/src/ml_pipeline_studio/ui/inspector_bin.py
+++ b/src/ml_pipeline_studio/ui/inspector_bin.py
@@ -1,0 +1,29 @@
+"""Inspector dock: streamlined NodeGraphQt properties bin without legacy toolbar chrome."""
+
+from __future__ import annotations
+
+from NodeGraphQt import PropertiesBinWidget
+
+
+class RedshalePropertiesBinWidget(PropertiesBinWidget):
+    """Properties bin focused on the selected node — hides limit / lock / clear row."""
+
+    def __init__(self, parent=None, node_graph=None) -> None:
+        super().__init__(parent=parent, node_graph=node_graph)
+        self._prop_list.setObjectName("InspectorNodeList")
+        self._strip_legacy_toolbar()
+
+    def _strip_legacy_toolbar(self) -> None:
+        vl = self.layout()
+        if vl is None or vl.count() < 1:
+            return
+        item = vl.itemAt(0)
+        top = item.layout() if item is not None else None
+        if top is None:
+            return
+        for i in range(top.count()):
+            w = top.itemAt(i).widget()
+            if w is not None:
+                w.hide()
+        top.setContentsMargins(0, 0, 0, 0)
+        top.setSpacing(0)

--- a/src/ml_pipeline_studio/ui/main_window.py
+++ b/src/ml_pipeline_studio/ui/main_window.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from NodeGraphQt import NodeGraph, PropertiesBinWidget
+from NodeGraphQt import NodeGraph
 from PySide6.QtCore import QObject, QSettings, Qt, QThread, QTimer, Signal, Slot
 from PySide6.QtGui import QAction, QKeySequence
 from PySide6.QtWidgets import (
@@ -28,6 +28,7 @@ from ml_pipeline_studio.ui.graph_bridge import (
 )
 from ml_pipeline_studio.ui.graph_nodes import KIND_TO_NODE_TYPE
 from ml_pipeline_studio.ui.header_nav import HeaderNavBar
+from ml_pipeline_studio.ui.inspector_bin import RedshalePropertiesBinWidget
 from ml_pipeline_studio.ui.terminal_panel import TerminalPanel
 from ml_pipeline_studio.ui.welcome_dialog import WelcomeDialog
 
@@ -152,9 +153,9 @@ class _RunWorker(QObject):
 class MainWindow(QMainWindow):
     def __init__(self) -> None:
         super().__init__()
-        self.setWindowTitle("ML Pipeline Studio")
+        self.setWindowTitle("Redshale")
         self.resize(1200, 800)
-        self._qsettings = QSettings("ML Pipeline Studio", "ML Pipeline Studio")
+        self._qsettings = QSettings("Redshale", "Redshale")
 
         self._graph = NodeGraph()
         register_studio_nodes(self._graph)
@@ -168,8 +169,10 @@ class MainWindow(QMainWindow):
 
         self.setCentralWidget(self._graph.widget)
 
-        self._props = PropertiesBinWidget(node_graph=self._graph)
+        self._props = RedshalePropertiesBinWidget(node_graph=self._graph)
+        self._props.setObjectName("InspectorPane")
         dock_p = QDockWidget("Inspector", self)
+        dock_p.setObjectName("InspectorDock")
         dock_p.setWidget(self._props)
         self.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, dock_p)
 
@@ -249,7 +252,7 @@ class MainWindow(QMainWindow):
         self._graph.clear_session()
         self._settings = GlobalSettings()
         self._current_path = None
-        self.setWindowTitle("ML Pipeline Studio — Untitled")
+        self.setWindowTitle("Redshale — Untitled")
         self._header.set_file_label("Untitled pipeline")
         self._log.clear()
 
@@ -265,7 +268,7 @@ class MainWindow(QMainWindow):
             self._settings = doc.settings
             apply_document_to_graph(self._graph, doc)
             self._current_path = Path(path)
-            self.setWindowTitle(f"ML Pipeline Studio — {self._current_path.name}")
+            self.setWindowTitle(f"Redshale — {self._current_path.name}")
             self._header.set_file_label(self._current_path.name)
             self._remember_recent_file(self._current_path)
             return True
@@ -288,7 +291,7 @@ class MainWindow(QMainWindow):
             p = p.with_suffix(".json")
         self._save_to(p)
         self._current_path = p
-        self.setWindowTitle(f"ML Pipeline Studio — {p.name}")
+        self.setWindowTitle(f"Redshale — {p.name}")
         self._header.set_file_label(p.name)
 
     def _save_to(self, path: Path) -> None:
@@ -301,7 +304,7 @@ class MainWindow(QMainWindow):
         self._settings = doc.settings
         apply_document_to_graph(self._graph, doc)
         self._current_path = None
-        self.setWindowTitle("ML Pipeline Studio — Template (unsaved)")
+        self.setWindowTitle("Redshale — Template (unsaved)")
         self._header.set_file_label("Template (unsaved)")
         QMessageBox.information(
             self,

--- a/src/ml_pipeline_studio/ui/redshale_brand.py
+++ b/src/ml_pipeline_studio/ui/redshale_brand.py
@@ -1,0 +1,50 @@
+"""Shared Redshale wordmark + dot (same visual language as the nav bar)."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QHBoxLayout, QLabel, QSizePolicy, QWidget
+
+BrandVariant = Literal["header", "welcome"]
+
+
+def create_redshale_brand_widget(
+    parent: QWidget | None = None,
+    *,
+    variant: BrandVariant = "header",
+) -> QWidget:
+    """Return a horizontal ``Redshale`` label plus accent dot."""
+    if variant == "header":
+        container_name = "HeaderBrand"
+        word_name = "HeaderBrandWord"
+        dot_name = "HeaderBrandDot"
+    else:
+        container_name = "WelcomeBrand"
+        word_name = "WelcomeBrandWord"
+        dot_name = "WelcomeBrandDot"
+
+    brand = QWidget(parent)
+    brand.setObjectName(container_name)
+    row = QHBoxLayout(brand)
+    row.setContentsMargins(0, 0, 0, 0)
+    row.setSpacing(0)
+
+    brand_word = QLabel("Redshale")
+    brand_word.setObjectName(word_name)
+    brand_word.setToolTip("Redshale")
+    brand_word.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
+
+    brand_dot = QLabel("●")
+    brand_dot.setObjectName(dot_name)
+    brand_dot.setToolTip("Redshale")
+    brand_dot.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
+
+    row.addWidget(brand_word, 0, Qt.AlignmentFlag.AlignVCenter)
+    row.addWidget(brand_dot, 0, Qt.AlignmentFlag.AlignVCenter)
+
+    if variant == "welcome":
+        brand.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+
+    return brand

--- a/src/ml_pipeline_studio/ui/theme.py
+++ b/src/ml_pipeline_studio/ui/theme.py
@@ -2,7 +2,9 @@
 
 Provides a single ``apply_theme(app)`` entrypoint that installs a Fusion
 palette and a stylesheet which gives the app a clean, flat look with rounded
-controls, a dim chrome and a softened red accent. UI font stack prefers native system fonts (install ``Plus Jakarta Sans`` to match web branding).
+controls, a dim chrome and a softened red accent. The font stack prefers
+native system fonts; install Plus Jakarta Sans for closer parity with web
+branding.
 """
 
 from __future__ import annotations

--- a/src/ml_pipeline_studio/ui/theme.py
+++ b/src/ml_pipeline_studio/ui/theme.py
@@ -1,8 +1,8 @@
-"""Modern dark theme inspired by VS Code.
+"""Modern dark theme inspired by VS Code layout.
 
 Provides a single ``apply_theme(app)`` entrypoint that installs a Fusion
 palette and a stylesheet which gives the app a clean, flat look with rounded
-controls, a dim chrome and an accent color matching VS Code's blue.
+controls, a dim chrome and a softened red accent. UI font stack prefers native system fonts (install ``Plus Jakarta Sans`` to match web branding).
 """
 
 from __future__ import annotations
@@ -22,8 +22,8 @@ COLORS = {
     "text": "#cccccc",
     "text_dim": "#9d9d9d",
     "text_strong": "#ffffff",
-    "accent": "#0e639c",         # VS Code "command" blue
-    "accent_hi": "#1177bb",
+    "accent": "#de5c5c",         # softened red (less saturated than red-600)
+    "accent_hi": "#ec8a8a",      # hover: lighter, muted
     "danger": "#a1260d",
     "ok": "#16825d",
 }
@@ -59,11 +59,11 @@ def _build_stylesheet() -> str:
     QMainWindow, QWidget {{
         background-color: {c["chrome"]};
         color: {c["text"]};
-        font-family: "Helvetica Neue", Arial, sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
         font-size: 13px;
     }}
     * {{
-        font-family: "Helvetica Neue", Arial, sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
     }}
 
     QToolTip {{
@@ -78,17 +78,26 @@ def _build_stylesheet() -> str:
         background-color: {c["header"]};
         border-bottom: 1px solid #1a1a1a;
     }}
-    QLabel#HeaderTitle {{
-        color: {c["text_strong"]};
-        font-weight: 600;
-        font-size: 13px;
-        padding-left: 8px;
+    QWidget#HeaderBrand {{
+        padding-left: 36px;
+        padding-top: 0;
+        padding-right: 0;
+        padding-bottom: 0;
     }}
-    QLabel#HeaderLogo {{
-        color: {c["accent_hi"]};
-        font-size: 16px;
+    QLabel#HeaderBrandWord {{
+        color: {c["text_strong"]};
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+        font-weight: 500;
+        font-size: 15px;
+        letter-spacing: -0.02em;
+    }}
+    QLabel#HeaderBrandDot {{
+        color: {c["accent"]};
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+        font-size: 8px;
         font-weight: 700;
-        padding-left: 12px;
+        padding-left: 1px;
+        padding-bottom: 2px;
     }}
     QLabel#HeaderFile {{
         color: {c["text_dim"]};
@@ -138,11 +147,11 @@ def _build_stylesheet() -> str:
         background-color: {c["accent_hi"]};
     }}
     QToolButton#HeaderRunButton:pressed {{
-        background-color: #0a4f7d;
+        background-color: #c24a4a;
     }}
     QToolButton#HeaderRunButton:disabled {{
-        background-color: #2a4a60;
-        color: #99b3c2;
+        background-color: #5a4545;
+        color: #d8bcbc;
     }}
 
     /* Menus */
@@ -244,10 +253,64 @@ def _build_stylesheet() -> str:
     QDialog#WelcomeDialog {{
         background-color: {c["chrome"]};
     }}
+    QFrame#WelcomeHero {{
+        background-color: {c["bg"]};
+        border: 1px solid {c["border_strong"]};
+        border-radius: 14px;
+    }}
+    QFrame#WelcomeHero QLabel#WelcomeBrandWord {{
+        color: {c["text_strong"]};
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+        font-weight: 700;
+        font-size: 28px;
+        letter-spacing: -0.03em;
+    }}
+    QFrame#WelcomeHero QLabel#WelcomeBrandDot {{
+        color: {c["accent"]};
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+        font-size: 14px;
+        font-weight: 700;
+        padding-left: 3px;
+        padding-bottom: 9px;
+    }}
+    QFrame#WelcomeSeparator {{
+        background-color: {c["border"]};
+        border: none;
+        min-height: 1px;
+        max-height: 1px;
+    }}
+    QLabel#WelcomeTagline {{
+        color: {c["text_dim"]};
+        font-size: 13px;
+        padding: 0 12px;
+    }}
+    QFrame#WelcomeRecentCard {{
+        background-color: {c["chrome_alt"]};
+        border: 1px solid {c["border_strong"]};
+        border-radius: 12px;
+    }}
     QFrame#WelcomePanel {{
         background-color: {c["chrome_alt"]};
         border: 1px solid {c["border_strong"]};
         border-radius: 10px;
+    }}
+    QWidget#WelcomeBrand {{
+        padding-left: 0;
+    }}
+    QLabel#WelcomeBrandWord {{
+        color: {c["text_strong"]};
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+        font-weight: 700;
+        font-size: 22px;
+        letter-spacing: -0.02em;
+    }}
+    QLabel#WelcomeBrandDot {{
+        color: {c["accent"]};
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+        font-size: 11px;
+        font-weight: 700;
+        padding-left: 2px;
+        padding-bottom: 6px;
     }}
     QLabel#WelcomeTitle {{
         color: {c["text_strong"]};
@@ -308,5 +371,78 @@ def _build_stylesheet() -> str:
     QPushButton#WelcomeSkip:hover {{
         color: {c["text"]};
         text-decoration: underline;
+    }}
+
+    /* Inspector dock — properties bin */
+    QWidget#InspectorPane {{
+        background-color: {c["chrome"]};
+    }}
+    QWidget#InspectorNodeCard {{
+        background-color: {c["chrome"]};
+    }}
+    QLabel#InspectorNodeIcon {{
+        padding-right: 8px;
+    }}
+    QLabel#InspectorHeaderLabel {{
+        color: {c["text_dim"]};
+        font-size: 11px;
+        font-weight: 600;
+        letter-spacing: 0.06em;
+        min-width: 44px;
+    }}
+    QTableWidget#InspectorNodeList {{
+        background-color: transparent;
+        border: none;
+        outline: none;
+    }}
+    QTableWidget#InspectorNodeList::item {{
+        padding: 8px 6px;
+        border: none;
+    }}
+    QFrame#InspectorField {{
+        background-color: {c["chrome_alt"]};
+        border: 1px solid {c["border_strong"]};
+        border-radius: 10px;
+    }}
+    QLabel#InspectorPropLabel {{
+        color: {c["text_dim"]};
+        font-size: 11px;
+        font-weight: 600;
+        letter-spacing: 0.05em;
+        min-width: 108px;
+        max-width: 150px;
+    }}
+    QTabWidget#InspectorTabs::pane {{
+        border: 1px solid {c["border_strong"]};
+        border-radius: 10px;
+        background-color: {c["bg"]};
+        padding: 14px 12px;
+        top: -1px;
+    }}
+    QTabWidget#InspectorTabs QTabBar::tab {{
+        background-color: transparent;
+        color: {c["text_dim"]};
+        border: none;
+        padding: 10px 14px;
+        margin-right: 4px;
+        min-height: 20px;
+    }}
+    QTabWidget#InspectorTabs QTabBar::tab:selected {{
+        color: {c["text_strong"]};
+        font-weight: 600;
+        border-bottom: 2px solid {c["accent"]};
+        padding-bottom: 8px;
+    }}
+    QLabel#InspectorNodeTypeFooter {{
+        color: {c["text_dim"]};
+        font-size: 10px;
+        padding-top: 10px;
+        font-family: ui-monospace, "JetBrains Mono", monospace;
+    }}
+    QFrame#InspectorField QComboBox,
+    QFrame#InspectorField QLineEdit,
+    QFrame#InspectorField QAbstractSpinBox {{
+        min-height: 28px;
+        border-radius: 6px;
     }}
     """

--- a/src/ml_pipeline_studio/ui/tutorial_dialog.py
+++ b/src/ml_pipeline_studio/ui/tutorial_dialog.py
@@ -65,7 +65,7 @@ class TutorialDialog(QDialog):
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self.setObjectName("WelcomeDialog")
-        self.setWindowTitle("How to use this app")
+        self.setWindowTitle("How to use Redshale")
         self.setModal(True)
         self.resize(620, 430)
         self.setMinimumSize(560, 390)
@@ -85,7 +85,7 @@ class TutorialDialog(QDialog):
         lay.setContentsMargins(24, 24, 24, 20)
         lay.setSpacing(14)
 
-        title = QLabel("How to use ML Pipeline Studio")
+        title = QLabel("How to use Redshale")
         title.setObjectName("WelcomeTitle")
         lay.addWidget(title)
 

--- a/src/ml_pipeline_studio/ui/welcome_dialog.py
+++ b/src/ml_pipeline_studio/ui/welcome_dialog.py
@@ -1,4 +1,4 @@
-"""VS Code-style startup welcome page."""
+"""Modern startup welcome dialog with Redshale wordmark."""
 
 from __future__ import annotations
 
@@ -15,10 +15,11 @@ from PySide6.QtWidgets import (
     QListWidget,
     QListWidgetItem,
     QPushButton,
-    QSizePolicy,
     QVBoxLayout,
     QWidget,
 )
+
+from ml_pipeline_studio.ui.redshale_brand import create_redshale_brand_widget
 
 WelcomeChoice = Literal["open", "open_recent", "new", "skip"]
 
@@ -29,47 +30,61 @@ class WelcomeDialog(QDialog):
     def __init__(self, recent_files: Iterable[str], parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self.setObjectName("WelcomeDialog")
-        self.setWindowTitle("Welcome to ML Pipeline Studio")
+        self.setWindowTitle("Welcome to Redshale")
         self.setModal(True)
-        self.resize(760, 500)
-        self.setMinimumWidth(680)
+        self.resize(820, 540)
+        self.setMinimumWidth(720)
 
         self._choice: WelcomeChoice = "skip"
         self._selected_recent: str | None = None
 
         root = QVBoxLayout(self)
-        root.setContentsMargins(24, 24, 24, 20)
-        root.setSpacing(12)
+        root.setContentsMargins(32, 28, 32, 22)
+        root.setSpacing(0)
 
-        panel = QFrame()
-        panel.setObjectName("WelcomePanel")
-        root.addWidget(panel)
-        lay = QVBoxLayout(panel)
-        lay.setContentsMargins(22, 22, 22, 18)
-        lay.setSpacing(16)
+        hero = QFrame()
+        hero.setObjectName("WelcomeHero")
+        hero_lay = QVBoxLayout(hero)
+        hero_lay.setContentsMargins(28, 28, 28, 24)
+        hero_lay.setSpacing(14)
 
-        title = QLabel("ML Pipeline Studio")
-        title.setObjectName("WelcomeTitle")
-        title.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        brand_row = QHBoxLayout()
+        brand_row.addStretch(1)
+        brand = create_redshale_brand_widget(hero, variant="welcome")
+        brand_row.addWidget(brand, 0, Qt.AlignmentFlag.AlignCenter)
+        brand_row.addStretch(1)
+        hero_lay.addLayout(brand_row)
 
-        subtitle = QLabel("Start where you left off, open an existing pipeline, or create a new one.")
-        subtitle.setObjectName("WelcomeSubtitle")
-        subtitle.setWordWrap(True)
+        tagline = QLabel(
+            "Build and run ML pipelines as a visual node graph — datasets, training, and export in one flow."
+        )
+        tagline.setObjectName("WelcomeTagline")
+        tagline.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        tagline.setWordWrap(True)
+        hero_lay.addWidget(tagline)
 
-        lay.addWidget(title)
-        lay.addWidget(subtitle)
-        lay.addSpacing(2)
+        root.addWidget(hero)
+
+        sep = QFrame()
+        sep.setObjectName("WelcomeSeparator")
+        sep.setFixedHeight(1)
+        root.addWidget(sep)
+
+        root.addSpacing(22)
 
         actions = QHBoxLayout()
-        actions.setSpacing(8)
-        btn_new = QPushButton("New File")
+        actions.setSpacing(10)
+        btn_new = QPushButton("New pipeline")
         btn_new.setObjectName("WelcomePrimary")
+        btn_new.setCursor(Qt.CursorShape.PointingHandCursor)
         btn_new.clicked.connect(self._on_new)
-        btn_open = QPushButton("Open File…")
+        btn_open = QPushButton("Open…")
         btn_open.setObjectName("WelcomeSecondary")
+        btn_open.setCursor(Qt.CursorShape.PointingHandCursor)
         btn_open.clicked.connect(self._on_open)
-        btn_open_recent = QPushButton("Open Selected")
+        btn_open_recent = QPushButton("Open selected")
         btn_open_recent.setObjectName("WelcomeSecondary")
+        btn_open_recent.setCursor(Qt.CursorShape.PointingHandCursor)
         btn_open_recent.clicked.connect(self._on_open_recent)
         self._btn_open_recent = btn_open_recent
         self._btn_open_recent.setEnabled(False)
@@ -78,24 +93,37 @@ class WelcomeDialog(QDialog):
         actions.addWidget(btn_open)
         actions.addWidget(btn_open_recent)
         actions.addStretch(1)
-        lay.addLayout(actions)
+        root.addLayout(actions)
 
-        recents_label = QLabel("Recent")
+        root.addSpacing(18)
+
+        recent_card = QFrame()
+        recent_card.setObjectName("WelcomeRecentCard")
+        recent_lay = QVBoxLayout(recent_card)
+        recent_lay.setContentsMargins(16, 14, 16, 14)
+        recent_lay.setSpacing(10)
+
+        recents_label = QLabel("Recent files")
         recents_label.setObjectName("WelcomeRecentLabel")
-        lay.addWidget(recents_label)
+        recent_lay.addWidget(recents_label)
 
-        self._recent_list = QListWidget(self)
+        self._recent_list = QListWidget(recent_card)
+        self._recent_list.setMinimumHeight(190)
         self._recent_list.setObjectName("WelcomeRecentList")
         self._recent_list.itemSelectionChanged.connect(self._on_recent_selection)
         self._recent_list.itemDoubleClicked.connect(self._on_recent_double_click)
-        lay.addWidget(self._recent_list, 1)
+        recent_lay.addWidget(self._recent_list, 1)
 
-        skip = QPushButton("Continue without changing workspace")
+        root.addWidget(recent_card, 1)
+
+        root.addSpacing(14)
+
+        skip = QPushButton("Continue to workspace")
         skip.setObjectName("WelcomeSkip")
         skip.setCursor(Qt.CursorShape.PointingHandCursor)
         skip.setAutoDefault(False)
         skip.clicked.connect(self._on_skip)
-        lay.addWidget(skip, 0, Qt.AlignmentFlag.AlignHCenter)
+        root.addWidget(skip, 0, Qt.AlignmentFlag.AlignHCenter)
 
         self._populate_recent_files(recent_files)
 


### PR DESCRIPTION
## Summary
- Rebrand visible strings to **Redshale** (README, pyproject, dialogs).
- Softer red accent and native-first font stack; nav wordmark + shared welcome hero branding.
- **Inspector**: grouped parameter tabs, field cards, streamlined properties bin, NodeGraphQt compat patches.
- Programmatic rounded window icon with black rounded background.

## Notes
Draft PR against `main`.

Made with [Cursor](https://cursor.com)